### PR TITLE
Implement `AsJValue` trait

### DIFF
--- a/jnix/src/as_jvalue.rs
+++ b/jnix/src/as_jvalue.rs
@@ -1,0 +1,13 @@
+use jni::objects::JValue;
+
+/// Returns a value as it's [`JValue`] representation.
+///
+/// [`JValue`]: https://docs.rs/jni/0.14.0/jni/objects/enum.JValue.html
+pub trait AsJValue<'env> {
+    /// Returns the [`JValue`] representation of the type.
+    ///
+    /// [`JValue`]: https://docs.rs/jni/0.14.0/jni/objects/enum.JValue.html
+    fn as_jvalue<'borrow>(&'borrow self) -> JValue<'borrow>
+    where
+        'env: 'borrow;
+}

--- a/jnix/src/as_jvalue.rs
+++ b/jnix/src/as_jvalue.rs
@@ -1,4 +1,4 @@
-use jni::objects::JValue;
+use jni::objects::{AutoLocal, JValue};
 
 /// Returns a value as it's [`JValue`] representation.
 ///
@@ -10,4 +10,13 @@ pub trait AsJValue<'env> {
     fn as_jvalue<'borrow>(&'borrow self) -> JValue<'borrow>
     where
         'env: 'borrow;
+}
+
+impl<'env_borrow, 'env: 'env_borrow> AsJValue<'env> for AutoLocal<'env, 'env_borrow> {
+    fn as_jvalue<'borrow>(&'borrow self) -> JValue<'borrow>
+    where
+        'env: 'borrow,
+    {
+        JValue::Object(self.as_obj())
+    }
 }

--- a/jnix/src/as_jvalue.rs
+++ b/jnix/src/as_jvalue.rs
@@ -20,3 +20,20 @@ impl<'env_borrow, 'env: 'env_borrow> AsJValue<'env> for AutoLocal<'env, 'env_bor
         JValue::Object(self.as_obj())
     }
 }
+
+macro_rules! impl_for_primitives {
+    ( $( $primitive:ty ),* $(,)* ) => {
+        $(
+            impl<'env> AsJValue<'env> for $primitive {
+                fn as_jvalue<'borrow>(&'borrow self) -> JValue<'borrow>
+                where
+                    'env: 'borrow,
+                {
+                    JValue::from(*self)
+                }
+            }
+        )*
+    };
+}
+
+impl_for_primitives!((), bool, u8, i8, u16, i16, i32, i64, f32, f64);

--- a/jnix/src/lib.rs
+++ b/jnix/src/lib.rs
@@ -7,6 +7,7 @@
 
 pub extern crate jni;
 
+mod as_jvalue;
 mod jnix_env;
 
-pub use self::jnix_env::JnixEnv;
+pub use self::{as_jvalue::AsJValue, jnix_env::JnixEnv};


### PR DESCRIPTION
This PR adds a trait to unify the conversions into `JValue`s so that they can be used as parameters in the generated code. For now, the trait is implemented for the supported primitive types and for the `AutoLocal` object wrapper type that is returned by generated `IntoJava` code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/jnix/2)
<!-- Reviewable:end -->
