### PR TITLE
Derive `IntoJava` for structs

### DIFF
--- a/jnix-macros/Cargo.toml
+++ b/jnix-macros/Cargo.toml
@@ -11,3 +11,6 @@ edition = "2018"
 proc-macro = true
 
 [dependencies]
+proc-macro2 = "1"
+quote = "1"
+syn = "1"

--- a/jnix-macros/Cargo.toml
+++ b/jnix-macros/Cargo.toml
@@ -13,4 +13,4 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1"
 quote = "1"
-syn = "1"
+syn = { version = "1", features = ['full'] }

--- a/jnix-macros/src/attributes.rs
+++ b/jnix-macros/src/attributes.rs
@@ -1,0 +1,41 @@
+use proc_macro2::Span;
+use std::collections::HashMap;
+use syn::{Attribute, Ident, Lit, LitStr, MetaNameValue};
+
+pub struct JnixAttributes {
+    key_value_pairs: HashMap<String, LitStr>,
+}
+
+impl JnixAttributes {
+    pub fn new(attributes: &Vec<Attribute>) -> Self {
+        let jnix_ident = Ident::new("jnix", Span::call_site());
+        let mut key_value_pairs = HashMap::new();
+
+        for attribute in attributes {
+            if attribute.path.is_ident(&jnix_ident) {
+                if let Ok(key_value_pair) = attribute.parse_args::<MetaNameValue>() {
+                    let key = key_value_pair
+                        .path
+                        .get_ident()
+                        .expect("Invalid jnix attribute key")
+                        .to_string();
+
+                    let value = match key_value_pair.lit {
+                        Lit::Str(value) => value,
+                        _ => panic!("Invalid jnix attribute value"),
+                    };
+
+                    key_value_pairs.insert(key, value);
+                } else {
+                    panic!("Invalid jnix attribute");
+                }
+            }
+        }
+
+        JnixAttributes { key_value_pairs }
+    }
+
+    pub fn get_value(&self, key: &str) -> Option<LitStr> {
+        self.key_value_pairs.get(key).cloned()
+    }
+}

--- a/jnix-macros/src/fields.rs
+++ b/jnix-macros/src/fields.rs
@@ -1,0 +1,57 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{Fields, LitStr};
+
+struct ParsedField;
+
+pub struct ParsedFields {
+    _fields: Vec<ParsedField>,
+}
+
+impl ParsedFields {
+    pub fn new(fields: Fields) -> Self {
+        ParsedFields {
+            _fields: Self::collect_parsed_fields(fields),
+        }
+    }
+
+    fn collect_parsed_fields(fields: Fields) -> Vec<ParsedField> {
+        match fields {
+            Fields::Unit => vec![],
+            _ => panic!("Only unit structs are currently supported"),
+        }
+    }
+
+    pub fn generate_struct_into_java(
+        &self,
+        jni_class_name_literal: &LitStr,
+        type_name_literal: &LitStr,
+        class_name: &str,
+    ) -> TokenStream {
+        self.generate_into_java_conversion(jni_class_name_literal, type_name_literal, class_name)
+    }
+
+    fn generate_into_java_conversion(
+        &self,
+        jni_class_name_literal: &LitStr,
+        type_name_literal: &LitStr,
+        class_name: &str,
+    ) -> TokenStream {
+        quote! {
+            let mut constructor_signature = String::with_capacity(3);
+
+            constructor_signature.push_str("()V");
+
+            let class = env.get_class(#jni_class_name_literal);
+            let object = env.new_object(&class, constructor_signature, &[])
+                .expect(concat!("Failed to convert ",
+                    #type_name_literal,
+                    " Rust type into ",
+                    #class_name,
+                    " Java object",
+                ));
+
+            env.auto_local(object)
+        }
+    }
+}

--- a/jnix-macros/src/fields.rs
+++ b/jnix-macros/src/fields.rs
@@ -1,24 +1,86 @@
-use proc_macro2::TokenStream;
+use crate::JnixAttributes;
+use proc_macro2::{Span, TokenStream};
 use quote::quote;
-use syn::{Fields, LitStr};
+use syn::{spanned::Spanned, Field, Fields, Ident, Index, LitStr, Member};
 
-struct ParsedField;
+pub struct ParsedField {
+    pub name: String,
+    pub field: Field,
+    pub attributes: JnixAttributes,
+    pub member: Member,
+    pub source_binding: Ident,
+    pub span: Span,
+}
+
+impl ParsedField {
+    pub fn new(
+        name: String,
+        field: Field,
+        attributes: JnixAttributes,
+        member: Member,
+        span: Span,
+    ) -> Self {
+        let source_binding = Ident::new(&format!("_source_{}", name), span);
+
+        ParsedField {
+            name,
+            field,
+            attributes,
+            member,
+            source_binding,
+            span,
+        }
+    }
+
+    pub fn from_named_field(field: Field) -> Option<Self> {
+        let attributes = JnixAttributes::new(&field.attrs);
+        let ident = field.ident.clone().expect("Named field with no name ident");
+        let span = ident.span();
+        let name = ident.to_string();
+        let member = Member::Named(ident);
+
+        Some(ParsedField::new(name, field, attributes, member, span))
+    }
+
+    pub fn from_unnamed_field((field, index): (Field, u32)) -> Option<Self> {
+        let attributes = JnixAttributes::new(&field.attrs);
+        let span = field.ty.span();
+        let name = format!("_{}", index);
+        let member = Member::Unnamed(Index { index, span });
+
+        Some(ParsedField::new(name, field, attributes, member, span))
+    }
+
+    pub fn binding(&self, prefix: &str) -> Ident {
+        Ident::new(&format!("_{}_{}", prefix, self.name), self.span)
+    }
+}
 
 pub struct ParsedFields {
-    _fields: Vec<ParsedField>,
+    fields: Vec<ParsedField>,
 }
 
 impl ParsedFields {
     pub fn new(fields: Fields) -> Self {
         ParsedFields {
-            _fields: Self::collect_parsed_fields(fields),
+            fields: Self::collect_parsed_fields(fields),
         }
     }
 
     fn collect_parsed_fields(fields: Fields) -> Vec<ParsedField> {
         match fields {
             Fields::Unit => vec![],
-            _ => panic!("Only unit structs are currently supported"),
+            Fields::Named(fields) => fields
+                .named
+                .into_iter()
+                .filter_map(ParsedField::from_named_field)
+                .collect(),
+            Fields::Unnamed(fields) => fields
+                .unnamed
+                .into_iter()
+                .zip(0..)
+                .filter_map(ParsedField::from_unnamed_field)
+                .collect(),
         }
     }
 
@@ -28,7 +90,18 @@ impl ParsedFields {
         type_name_literal: &LitStr,
         class_name: &str,
     ) -> TokenStream {
-        self.generate_into_java_conversion(jni_class_name_literal, type_name_literal, class_name)
+        let source_bindings = self.source_bindings();
+        let members = self.members();
+        let conversion = self.generate_into_java_conversion(
+            jni_class_name_literal,
+            type_name_literal,
+            class_name,
+        );
+
+        quote! {
+            #( let #source_bindings = self.#members; )*
+            #conversion
+        }
     }
 
     fn generate_into_java_conversion(
@@ -37,13 +110,25 @@ impl ParsedFields {
         type_name_literal: &LitStr,
         class_name: &str,
     ) -> TokenStream {
-        quote! {
-            let mut constructor_signature = String::with_capacity(3);
+        let signature_bindings = self.bindings("signature").collect();
+        let final_bindings = self.bindings("final").collect();
+        let declarations = self.declarations(&signature_bindings, &final_bindings);
 
-            constructor_signature.push_str("()V");
+        quote! {
+            #( #declarations )*
+
+            let mut constructor_signature = String::with_capacity(
+                1 + #( #signature_bindings.as_bytes().len() + )* 2
+            );
+
+            constructor_signature.push_str("(");
+            #( constructor_signature.push_str(#signature_bindings); )*
+            constructor_signature.push_str(")V");
+
+            let parameters = [ #( jnix::AsJValue::as_jvalue(&#final_bindings) ),* ];
 
             let class = env.get_class(#jni_class_name_literal);
-            let object = env.new_object(&class, constructor_signature, &[])
+            let object = env.new_object(&class, constructor_signature, &parameters)
                 .expect(concat!("Failed to convert ",
                     #type_name_literal,
                     " Rust type into ",
@@ -53,5 +138,40 @@ impl ParsedFields {
 
             env.auto_local(object)
         }
+    }
+
+    fn declarations<'a, 'b, 'c, 'z>(
+        &'a self,
+        signature_bindings: &'b Vec<Ident>,
+        final_bindings: &'c Vec<Ident>,
+    ) -> impl Iterator<Item = TokenStream> + 'z
+    where
+        'a: 'z,
+        'b: 'z,
+        'c: 'z,
+    {
+        self.fields
+            .iter()
+            .zip(signature_bindings.iter().zip(final_bindings.iter()))
+            .map(|(field, (signature_binding, final_binding))| {
+                let source_binding = &field.source_binding;
+
+                quote! {
+                    let #signature_binding = #source_binding.jni_signature();
+                    let #final_binding = #source_binding.into_java(env);
+                }
+            })
+    }
+
+    fn source_bindings(&self) -> impl Iterator<Item = &Ident> + '_ {
+        self.fields.iter().map(|field| &field.source_binding)
+    }
+
+    fn bindings(&self, prefix: &'static str) -> impl Iterator<Item = Ident> + '_ {
+        self.fields.iter().map(move |field| field.binding(prefix))
+    }
+
+    fn members(&self) -> impl Iterator<Item = &Member> + '_ {
+        self.fields.iter().map(|field| &field.member)
     }
 }

--- a/jnix-macros/src/lib.rs
+++ b/jnix-macros/src/lib.rs
@@ -18,8 +18,10 @@ use syn::{parse_macro_input, Data, DeriveInput, Fields, LitStr};
 
 /// Derives `IntoJava` for a type.
 ///
-/// The generated `IntoJava` implementation for a unit struct will simply call the default
-/// constructor of the target Java class.
+/// The generated `IntoJava` implementation for a struct will convert the field values into their
+/// respective Java types. Then, the target Java class is constructed by calling a constructor with
+/// the converted field values as parameters. Note that the field order is used as the constructor
+/// parameter order.
 ///
 /// The name of the target Java class must be specified using an attribute, like so:
 /// `#[jnix(class_name = "my.package.MyClass"]`.
@@ -49,6 +51,7 @@ pub fn derive_into_java(input: TokenStream) -> TokenStream {
 
             type JavaType = jnix::jni::objects::AutoLocal<'env, 'borrow>;
 
+            #[allow(non_snake_case)]
             fn into_java(self, env: &'borrow jnix::JnixEnv<'env>) -> Self::JavaType {
                 #conversion
             }

--- a/jnix-macros/src/lib.rs
+++ b/jnix-macros/src/lib.rs
@@ -4,3 +4,105 @@
 //!
 //! This is a companion crate to `jnix` that provides some procedural macros for interfacing JNI
 //! with Rust.
+
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+use proc_macro2::{Span, TokenStream as TokenStream2};
+use quote::quote;
+use syn::{
+    parse_macro_input, Attribute, Data, DeriveInput, Fields, Ident, Lit, LitStr, MetaNameValue,
+};
+
+/// Derives `IntoJava` for a type.
+///
+/// The generated `IntoJava` implementation for a unit struct will simply call the default
+/// constructor of the target Java class.
+///
+/// The name of the target Java class must be specified using an attribute, like so:
+/// `#[jnix(class_name = "my.package.MyClass"]`.
+#[proc_macro_derive(IntoJava, attributes(jnix))]
+pub fn derive_into_java(input: TokenStream) -> TokenStream {
+    let parsed_input = parse_macro_input!(input as DeriveInput);
+    let type_name = parsed_input.ident;
+    let type_name_literal = LitStr::new(&type_name.to_string(), Span::call_site());
+    let class_name = parse_java_class_name(&parsed_input.attrs).expect("Missing Java class name");
+    let jni_class_name = class_name.replace(".", "/");
+    let jni_class_name_literal = LitStr::new(&jni_class_name, Span::call_site());
+
+    let fields = extract_struct_fields(parsed_input.data);
+    let (parameter_conversion, parameter_signatures, parameters) = generate_parameters(fields);
+
+    let tokens = quote! {
+        impl<'borrow, 'env: 'borrow> jnix::IntoJava<'borrow, 'env> for #type_name {
+            const JNI_SIGNATURE: &'static str = concat!("L", #jni_class_name_literal, ";");
+
+            type JavaType = jnix::jni::objects::AutoLocal<'env, 'borrow>;
+
+            fn into_java(self, env: &'borrow jnix::JnixEnv<'env>) -> Self::JavaType {
+                let mut constructor_signature = String::with_capacity(
+                    1 + #( #parameter_signatures.as_bytes().len() + )* 2
+                );
+
+                constructor_signature.push_str("(");
+                #( constructor_signature.push_str(#parameter_signatures); )*
+                constructor_signature.push_str(")V");
+
+                #( #parameter_conversion )*
+
+                let parameters = [ #( jnix::AsJValue::as_jvalue(&#parameters) ),* ];
+
+                let class = env.get_class(#jni_class_name_literal);
+                let object = env.new_object(&class, constructor_signature, &parameters)
+                    .expect(concat!(
+                        "Failed to convert ",
+                        #type_name_literal,
+                        " Rust type into ",
+                        #class_name,
+                        " Java object",
+                    ));
+
+                env.auto_local(object)
+            }
+        }
+    };
+
+    TokenStream::from(tokens)
+}
+
+fn parse_java_class_name(attributes: &Vec<Attribute>) -> Option<String> {
+    let jnix_ident = Ident::new("jnix", Span::call_site());
+    let jnix_attribute = attributes
+        .iter()
+        .find(|attribute| attribute.path.is_ident(&jnix_ident))?;
+    let meta: MetaNameValue = jnix_attribute.parse_args().expect("Invalid jnix attribute");
+
+    if meta
+        .path
+        .is_ident(&Ident::new("class_name", Span::call_site()))
+    {
+        if let Lit::Str(class_name) = meta.lit {
+            Some(class_name.value())
+        } else {
+            None
+        }
+    } else {
+        None
+    }
+}
+
+fn extract_struct_fields(data: Data) -> Fields {
+    match data {
+        Data::Struct(data) => data.fields,
+        _ => panic!("Dervie(IntoJava) only supported on structs"),
+    }
+}
+
+fn generate_parameters(
+    fields: Fields,
+) -> (Vec<TokenStream2>, Vec<TokenStream2>, Vec<TokenStream2>) {
+    match fields {
+        Fields::Unit => (vec![], vec![], vec![]),
+        _ => panic!("Derive(IntoJava) only supported on unit structs"),
+    }
+}


### PR DESCRIPTION
This PR implements the initial derive procedural macro for `IntoJava`. For this PR, only structs are supported, and no generic parameters are supported.

A `JnixAttributes` helper type is included to help with parsing and extracting information from custom `jnix` attributes.

Parsing the fields and generating the code for them is handled in a separate `ParsedFields` type.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/jnix/4)
<!-- Reviewable:end -->
