### PR TITLE
Allow preconverting a field value

### DIFF
--- a/jnix-macros/src/fields.rs
+++ b/jnix-macros/src/fields.rs
@@ -1,7 +1,10 @@
 use crate::JnixAttributes;
 use proc_macro2::{Span, TokenStream};
 use quote::quote;
-use syn::{parse_str, spanned::Spanned, ExprClosure, Field, Fields, Ident, Index, LitStr, Member};
+use syn::{
+    parse_str, spanned::Spanned, ExprClosure, Field, Fields, Ident, Index, LitStr, Member, Pat,
+    PatType, Token,
+};
 
 pub struct ParsedField {
     pub name: String,
@@ -60,12 +63,42 @@ impl ParsedField {
 
         match self.attributes.get_value("map") {
             Some(closure_string_literal) => {
-                let closure: ExprClosure = parse_str(&closure_string_literal.value())
+                let mut closure = parse_str(&closure_string_literal.value())
                     .expect("Invalid closure syntax in jnix(map = ...) attribute");
+
+                self.prepare_map_closure(&mut closure);
 
                 quote! { (#closure)(#source) }
             }
             None => quote! { #source },
+        }
+    }
+
+    fn prepare_map_closure(&self, closure: &mut ExprClosure) {
+        assert!(
+            closure.inputs.len() <= 1,
+            "Too many parameters in jnix(map = ...) closure"
+        );
+
+        let input = closure
+            .inputs
+            .pop()
+            .expect("Missing parameter in jnix(map = ...) closure")
+            .into_value();
+
+        closure.inputs.push_value(self.add_type_to_parameter(input));
+    }
+
+    fn add_type_to_parameter(&self, parameter: Pat) -> Pat {
+        if let &Pat::Type(_) = &parameter {
+            parameter
+        } else {
+            Pat::Type(PatType {
+                attrs: vec![],
+                pat: Box::new(parameter),
+                colon_token: Token![:](Span::call_site()),
+                ty: Box::new(self.field.ty.clone()),
+            })
         }
     }
 }

--- a/jnix-macros/src/lib.rs
+++ b/jnix-macros/src/lib.rs
@@ -23,6 +23,10 @@ use syn::{parse_macro_input, Data, DeriveInput, Fields, LitStr};
 /// the converted field values as parameters. Note that the field order is used as the constructor
 /// parameter order.
 ///
+/// Fields can be "preconverted" to a different Rust type, so that the resulting type is then used
+/// to convert to the Java type. To do so, use the `#[jnix(map = "|value| ...")]` attribute with a
+/// conversion closure.
+///
 /// The name of the target Java class must be specified using an attribute, like so:
 /// `#[jnix(class_name = "my.package.MyClass"]`.
 #[proc_macro_derive(IntoJava, attributes(jnix))]


### PR DESCRIPTION
In some cases, a field's type can't be directly converted to an equivalent Java type. In some of these cases, the solution is to convert it to a different type first, so that it can be converted to a different Java type in the end.

An example is a date/time. It might be preferred to convert a type representing the date/time into a Java `String` representing the date/time instead of a specific Java type. For such a case, the date/time in Rust would be "preconverted" to a Rust `String` before being converted to a Java `String`.

This PR adds a `#[jnix(map = "|value| ...")]` attribute that uses a closure to convert the original field value into a value of a different type which will then be used in the conversion to the final Java type.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/jnix/5)
<!-- Reviewable:end -->
