### PR TITLE
Allow skipping fields for Java conversion

### DIFF
--- a/jnix-macros/src/fields.rs
+++ b/jnix-macros/src/fields.rs
@@ -116,10 +116,14 @@ pub struct ParsedFields {
 }
 
 impl ParsedFields {
-    pub fn new(fields: Fields) -> Self {
-        ParsedFields {
-            fields: Self::collect_parsed_fields(fields),
-        }
+    pub fn new(fields: Fields, attributes: JnixAttributes) -> Self {
+        let fields = if attributes.has_flag("skip_all") {
+            vec![]
+        } else {
+            Self::collect_parsed_fields(fields)
+        };
+
+        ParsedFields { fields }
     }
 
     fn collect_parsed_fields(fields: Fields) -> Vec<ParsedField> {

--- a/jnix-macros/src/fields.rs
+++ b/jnix-macros/src/fields.rs
@@ -36,22 +36,30 @@ impl ParsedField {
     }
 
     pub fn from_named_field(field: Field) -> Option<Self> {
-        let attributes = JnixAttributes::new(&field.attrs);
         let ident = field.ident.clone().expect("Named field with no name ident");
         let span = ident.span();
         let name = ident.to_string();
         let member = Member::Named(ident);
 
-        Some(ParsedField::new(name, field, attributes, member, span))
+        Self::from_field(field, span, name, member)
     }
 
     pub fn from_unnamed_field((field, index): (Field, u32)) -> Option<Self> {
-        let attributes = JnixAttributes::new(&field.attrs);
         let span = field.ty.span();
         let name = format!("_{}", index);
         let member = Member::Unnamed(Index { index, span });
 
-        Some(ParsedField::new(name, field, attributes, member, span))
+        Self::from_field(field, span, name, member)
+    }
+
+    fn from_field(field: Field, span: Span, name: String, member: Member) -> Option<Self> {
+        let attributes = JnixAttributes::new(&field.attrs);
+
+        if attributes.has_flag("skip") {
+            None
+        } else {
+            Some(ParsedField::new(name, field, attributes, member, span))
+        }
     }
 
     pub fn binding(&self, prefix: &str) -> Ident {

--- a/jnix-macros/src/lib.rs
+++ b/jnix-macros/src/lib.rs
@@ -28,7 +28,8 @@ use syn::{parse_macro_input, Data, DeriveInput, Fields, LitStr};
 /// conversion closure.
 ///
 /// Fields can be skipped using the `#[jnix(skip)]` attribute, so that they aren't used in the
-/// conversion process, and therefore not used as a parameter for the constructor.
+/// conversion process, and therefore not used as a parameter for the constructor. The
+/// `#[jnix(skip_all)]` attribute can be used on the struct to skip all fields.
 ///
 /// The name of the target Java class must be specified using an attribute, like so:
 /// `#[jnix(class_name = "my.package.MyClass"]`.
@@ -46,7 +47,7 @@ pub fn derive_into_java(input: TokenStream) -> TokenStream {
     let jni_class_name_literal = LitStr::new(&jni_class_name, Span::call_site());
 
     let fields = extract_struct_fields(parsed_input.data);
-    let conversion = ParsedFields::new(fields).generate_struct_into_java(
+    let conversion = ParsedFields::new(fields, attributes).generate_struct_into_java(
         &jni_class_name_literal,
         &type_name_literal,
         &class_name,

--- a/jnix-macros/src/lib.rs
+++ b/jnix-macros/src/lib.rs
@@ -27,6 +27,9 @@ use syn::{parse_macro_input, Data, DeriveInput, Fields, LitStr};
 /// to convert to the Java type. To do so, use the `#[jnix(map = "|value| ...")]` attribute with a
 /// conversion closure.
 ///
+/// Fields can be skipped using the `#[jnix(skip)]` attribute, so that they aren't used in the
+/// conversion process, and therefore not used as a parameter for the constructor.
+///
 /// The name of the target Java class must be specified using an attribute, like so:
 /// `#[jnix(class_name = "my.package.MyClass"]`.
 #[proc_macro_derive(IntoJava, attributes(jnix))]


### PR DESCRIPTION
This PR adds another option for Rust types that can't or don't need all of its fields converted to Java. Individual fields can be skipped with a `#[jnix(skip)]` attribute, and all of the fields of a struct can be skipped with a `#[jnix(skip_all)]` attribute.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/jnix/6)
<!-- Reviewable:end -->
