### PR TITLE
Derive `IntoJava` for simple enums

### DIFF
--- a/jnix-macros/src/fields.rs
+++ b/jnix-macros/src/fields.rs
@@ -116,7 +116,7 @@ pub struct ParsedFields {
 }
 
 impl ParsedFields {
-    pub fn new(fields: Fields, attributes: JnixAttributes) -> Self {
+    pub fn new(fields: Fields, attributes: &JnixAttributes) -> Self {
         let fields = if attributes.has_flag("skip_all") {
             vec![]
         } else {

--- a/jnix-macros/src/lib.rs
+++ b/jnix-macros/src/lib.rs
@@ -10,12 +10,21 @@ extern crate proc_macro;
 mod attributes;
 mod fields;
 mod parsed_type;
+mod variants;
 
-use crate::{attributes::JnixAttributes, fields::ParsedFields, parsed_type::ParsedType};
+use crate::{
+    attributes::JnixAttributes, fields::ParsedFields, parsed_type::ParsedType,
+    variants::ParsedVariants,
+};
 use proc_macro::TokenStream;
 use syn::{parse_macro_input, DeriveInput};
 
 /// Derives `IntoJava` for a type.
+///
+/// The name of the target Java class must be specified using an attribute, like so:
+/// `#[jnix(class_name = "my.package.MyClass"]`.
+///
+/// # Structs
 ///
 /// The generated `IntoJava` implementation for a struct will convert the field values into their
 /// respective Java types. Then, the target Java class is constructed by calling a constructor with
@@ -30,8 +39,12 @@ use syn::{parse_macro_input, DeriveInput};
 /// conversion process, and therefore not used as a parameter for the constructor. The
 /// `#[jnix(skip_all)]` attribute can be used on the struct to skip all fields.
 ///
-/// The name of the target Java class must be specified using an attribute, like so:
-/// `#[jnix(class_name = "my.package.MyClass"]`.
+/// # Enums
+///
+/// The generated `IntoJava` implementation for a enum that only has unit variants (i.e., no tuple
+/// or struct variants) returns a static field value from the specified Java target class.  The
+/// name used for the static field in the Java class is the same as the Rust variant name. This
+/// allows the Rust enum to be mapped to a Java enum.
 #[proc_macro_derive(IntoJava, attributes(jnix))]
 pub fn derive_into_java(input: TokenStream) -> TokenStream {
     let parsed_type = ParsedType::new(parse_macro_input!(input as DeriveInput));

--- a/jnix-macros/src/parsed_type.rs
+++ b/jnix-macros/src/parsed_type.rs
@@ -1,0 +1,84 @@
+use crate::{JnixAttributes, ParsedFields};
+use proc_macro2::{Span, TokenStream};
+use quote::quote;
+use syn::{Data, DeriveInput, Ident, LitStr};
+
+pub struct ParsedType {
+    attributes: JnixAttributes,
+    type_name: Ident,
+    data: TypeData,
+}
+
+impl ParsedType {
+    pub fn new(input: DeriveInput) -> Self {
+        let attributes = JnixAttributes::new(&input.attrs);
+        let data = TypeData::from(input.data, &attributes);
+
+        ParsedType {
+            attributes,
+            type_name: input.ident,
+            data,
+        }
+    }
+
+    pub fn generate_into_java(self) -> TokenStream {
+        let type_name = self.type_name;
+        let type_name_literal = LitStr::new(&type_name.to_string(), Span::call_site());
+
+        let class_name = self
+            .attributes
+            .get_value("class_name")
+            .expect("Missing Java class name")
+            .value();
+
+        let jni_class_name = class_name.replace(".", "/");
+        let jni_class_name_literal = LitStr::new(&jni_class_name, Span::call_site());
+
+        let body = self.data.generate_into_java_body(
+            &jni_class_name_literal,
+            &type_name_literal,
+            &class_name,
+        );
+
+        quote! {
+            impl<'borrow, 'env: 'borrow> jnix::IntoJava<'borrow, 'env> for #type_name {
+                const JNI_SIGNATURE: &'static str = concat!("L", #jni_class_name_literal, ";");
+
+                type JavaType = jnix::jni::objects::AutoLocal<'env, 'borrow>;
+
+                #[allow(non_snake_case)]
+                fn into_java(self, env: &'borrow jnix::JnixEnv<'env>) -> Self::JavaType {
+                    #body
+                }
+            }
+        }
+    }
+}
+
+enum TypeData {
+    Struct(ParsedFields),
+}
+
+impl TypeData {
+    pub fn from(input_data: Data, attributes: &JnixAttributes) -> Self {
+        match input_data {
+            Data::Struct(data) => TypeData::Struct(ParsedFields::new(data.fields, attributes)),
+            _ => panic!("Dervie(IntoJava) only supported on structs"),
+        }
+    }
+
+    pub fn generate_into_java_body(
+        self,
+        jni_class_name_literal: &LitStr,
+        type_name_literal: &LitStr,
+        class_name: &str,
+    ) -> TokenStream {
+        match self {
+            TypeData::Struct(fields) => fields.generate_struct_into_java(
+                jni_class_name_literal,
+                type_name_literal,
+                class_name,
+            ),
+        }
+    }
+}

--- a/jnix-macros/src/variants.rs
+++ b/jnix-macros/src/variants.rs
@@ -1,0 +1,88 @@
+use proc_macro2::{Span, TokenStream};
+use quote::quote;
+use syn::{punctuated::Punctuated, Fields, Ident, LitStr, Token, Variant};
+
+pub struct ParsedVariants {
+    names: Vec<Ident>,
+}
+
+impl ParsedVariants {
+    pub fn new(variants: Punctuated<Variant, Token![,]>) -> Self {
+        let only_has_unit_fields = variants.iter().all(|variant| match variant.fields {
+            Fields::Unit => true,
+            _ => false,
+        });
+
+        if !only_has_unit_fields {
+            panic!("Derive(IntoJava) not supported on enums with fields")
+        }
+
+        ParsedVariants {
+            names: variants.into_iter().map(|variant| variant.ident).collect(),
+        }
+    }
+
+    pub fn generate_enum_into_java(
+        self,
+        jni_class_name_literal: &LitStr,
+        type_name_literal: &LitStr,
+        class_name: &str,
+    ) -> TokenStream {
+        let conversions = self.generate_variant_conversions(
+            jni_class_name_literal,
+            type_name_literal,
+            class_name,
+        );
+
+        let variants = self.names;
+
+        quote! {
+            match self {
+                #(
+                    Self::#variants => {
+                        #conversions
+                    }
+                )*
+            }
+        }
+    }
+
+    fn generate_variant_conversions(
+        &self,
+        jni_class_name_literal: &LitStr,
+        type_name_literal: &LitStr,
+        class_name: &str,
+    ) -> Vec<TokenStream> {
+        self.names
+            .iter()
+            .map(|variant_name| {
+                let variant_name_literal =
+                    LitStr::new(&variant_name.to_string(), Span::call_site());
+
+                quote! {
+                    let class = env.get_class(#jni_class_name_literal);
+                    let variant = env.get_static_field(
+                        &class,
+                        #variant_name_literal,
+                        concat!("L", #jni_class_name_literal, ";"),
+                    ).expect(concat!("Failed to convert ",
+                        #type_name_literal, "::", #variant_name_literal,
+                        " Rust enum variant into ",
+                        #class_name,
+                        " Java enum class variant",
+                    ));
+
+                    match variant {
+                        jnix::jni::objects::JValue::Object(object) => env.auto_local(object),
+                        _ => panic!(concat!("Conversion from ",
+                            #type_name_literal, "::", #variant_name_literal,
+                            " Rust enum variant into ",
+                            #class_name,
+                            " Java object returned an invalid result.",
+                        )),
+                    }
+                }
+            })
+            .collect()
+    }
+}


### PR DESCRIPTION
This PR implements `derive(IntoJava)` for enums that only have unit variants. These enums are mapped to Java's enums so that each Rust variant, when converted, results in the usage of the respective Java enum's variant.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/jnix/7)
<!-- Reviewable:end -->
