### PR TITLE
Implement `derive(IntoJava)` for complex enums

### DIFF
--- a/jnix-macros/src/attributes.rs
+++ b/jnix-macros/src/attributes.rs
@@ -8,6 +8,13 @@ pub struct JnixAttributes {
 }
 
 impl JnixAttributes {
+    pub fn empty() -> Self {
+        JnixAttributes {
+            flags: HashSet::new(),
+            key_value_pairs: HashMap::new(),
+        }
+    }
+
     pub fn new(attributes: &Vec<Attribute>) -> Self {
         let jnix_ident = Ident::new("jnix", Span::call_site());
         let mut flags = HashSet::new();

--- a/jnix-macros/src/lib.rs
+++ b/jnix-macros/src/lib.rs
@@ -45,6 +45,13 @@ use syn::{parse_macro_input, DeriveInput};
 /// or struct variants) returns a static field value from the specified Java target class.  The
 /// name used for the static field in the Java class is the same as the Rust variant name. This
 /// allows the Rust enum to be mapped to a Java enum.
+///
+/// When an enum has at least one tuple or struct variant, the generated `IntoJava` implementation
+/// will assume that that there is a class hierarchy to represent the type. The target Java class
+/// is used as the super class, and is the Java type returned from the conversion. The class is
+/// assumed to have one inner class for each variant, and the conversion actually instantiates an
+/// object for the respective variant type, using the same rules for the fields as the rules for
+/// struct fields.
 #[proc_macro_derive(IntoJava, attributes(jnix))]
 pub fn derive_into_java(input: TokenStream) -> TokenStream {
     let parsed_type = ParsedType::new(parse_macro_input!(input as DeriveInput));


### PR DESCRIPTION
This extends the derive procedural macro for `IntoJava` to handle enums with fields. Both tuple and struct variants are supported by reusing the code generated for structs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/jnix/8)
<!-- Reviewable:end -->
