### PR TITLE
Add support for type generics in derive procedural macro

### DIFF
--- a/jnix-macros/src/fields.rs
+++ b/jnix-macros/src/fields.rs
@@ -1,9 +1,9 @@
-use crate::JnixAttributes;
+use crate::{JnixAttributes, TypeParameters};
 use proc_macro2::{Span, TokenStream};
 use quote::quote;
 use syn::{
     parse_str, spanned::Spanned, ExprClosure, Field, Fields, Ident, Index, LitStr, Member, Pat,
-    PatType, Token,
+    PatType, Token, Type,
 };
 
 pub struct ParsedField {
@@ -60,6 +60,10 @@ impl ParsedField {
         } else {
             Some(ParsedField::new(name, field, attributes, member, span))
         }
+    }
+
+    pub fn get_type(&self) -> &Type {
+        &self.field.ty
     }
 
     pub fn binding(&self, prefix: &str) -> Ident {
@@ -179,6 +183,7 @@ impl ParsedFields {
         jni_class_name_literal: &LitStr,
         type_name_literal: &LitStr,
         class_name: &str,
+        type_parameters: &TypeParameters,
     ) -> TokenStream {
         let source_bindings = self.source_bindings();
         let members = self.members();
@@ -186,6 +191,7 @@ impl ParsedFields {
             jni_class_name_literal,
             type_name_literal,
             class_name,
+            type_parameters,
         );
 
         quote! {
@@ -199,6 +205,7 @@ impl ParsedFields {
         jni_class_name_literal: &LitStr,
         type_name_literal: &LitStr,
         class_name: &str,
+        type_parameters: &TypeParameters,
     ) -> TokenStream {
         let source_bindings = self.source_bindings();
         let original_bindings = self.original_bindings();
@@ -206,6 +213,7 @@ impl ParsedFields {
             jni_class_name_literal,
             type_name_literal,
             class_name,
+            type_parameters,
         );
 
         quote! {
@@ -219,10 +227,11 @@ impl ParsedFields {
         jni_class_name_literal: &LitStr,
         type_name_literal: &LitStr,
         class_name: &str,
+        type_parameters: &TypeParameters,
     ) -> TokenStream {
         let signature_bindings = self.bindings("signature").collect();
         let final_bindings = self.bindings("final").collect();
-        let declarations = self.declarations(&signature_bindings, &final_bindings);
+        let declarations = self.declarations(&signature_bindings, &final_bindings, type_parameters);
 
         quote! {
             #( #declarations )*
@@ -250,26 +259,34 @@ impl ParsedFields {
         }
     }
 
-    fn declarations<'a, 'b, 'c, 'z>(
+    fn declarations<'a, 'b, 'c, 'd, 'z>(
         &'a self,
         signature_bindings: &'b Vec<Ident>,
         final_bindings: &'c Vec<Ident>,
+        type_parameters: &'d TypeParameters,
     ) -> impl Iterator<Item = TokenStream> + 'z
     where
         'a: 'z,
         'b: 'z,
         'c: 'z,
+        'd: 'z,
     {
         self.fields
             .iter()
             .zip(signature_bindings.iter().zip(final_bindings.iter()))
-            .map(|(field, (signature_binding, final_binding))| {
+            .map(move |(field, (signature_binding, final_binding))| {
                 let converted_binding = field.binding("converted");
                 let conversion = field.preconversion();
 
+                let signature = if type_parameters.is_used_in_type(&field.get_type()) {
+                    quote! { "Ljava/lang/Object;" }
+                } else {
+                    quote! { #converted_binding.jni_signature() }
+                };
+
                 quote! {
                     let #converted_binding = #conversion;
-                    let #signature_binding = #converted_binding.jni_signature();
+                    let #signature_binding = #signature;
                     let #final_binding = #converted_binding.into_java(env);
                 }
             })

--- a/jnix-macros/src/fields.rs
+++ b/jnix-macros/src/fields.rs
@@ -278,7 +278,11 @@ impl ParsedFields {
                 let converted_binding = field.binding("converted");
                 let conversion = field.preconversion();
 
-                let signature = if type_parameters.is_used_in_type(&field.get_type()) {
+                let signature = if let Some(target) = field.attributes.get_value("target_class") {
+                    let signature = format!("L{};", target.value().replace(".", "/"));
+
+                    quote! { #signature }
+                } else if type_parameters.is_used_in_type(&field.get_type()) {
                     quote! { "Ljava/lang/Object;" }
                 } else {
                     quote! { #converted_binding.jni_signature() }

--- a/jnix-macros/src/generics.rs
+++ b/jnix-macros/src/generics.rs
@@ -7,6 +7,7 @@ use syn::{
 };
 
 pub struct ParsedGenerics {
+    type_parameters: Vec<Ident>,
     parameters: Vec<TokenStream>,
     constraints: Vec<TokenStream>,
 }
@@ -18,6 +19,7 @@ impl ParsedGenerics {
         let constraints = Self::collect_constraints(generics);
 
         ParsedGenerics {
+            type_parameters: types,
             parameters,
             constraints,
         }
@@ -77,6 +79,16 @@ impl ParsedGenerics {
             path: parse_str("jnix::IntoJava<'borrow, 'env>")
                 .expect("Invalid syntax in hardcoded string"),
         })
+    }
+
+    pub fn type_parameters(&self) -> TypeParameters {
+        TypeParameters {
+            params: self
+                .type_parameters
+                .iter()
+                .map(|param| param.to_string())
+                .collect(),
+        }
     }
 
     pub fn impl_generics(&self) -> TokenStream {

--- a/jnix-macros/src/generics.rs
+++ b/jnix-macros/src/generics.rs
@@ -1,0 +1,107 @@
+use proc_macro2::{Span, TokenStream};
+use quote::quote;
+use std::iter;
+use syn::{
+    parse_str, Generics, Ident, Lifetime, Token, TraitBound, TraitBoundModifier, TypeParamBound,
+};
+
+pub struct ParsedGenerics {
+    parameters: Vec<TokenStream>,
+    constraints: Vec<TokenStream>,
+}
+
+impl ParsedGenerics {
+    pub fn new(generics: &Generics) -> Self {
+        let (lifetimes, types) = Self::collect_generic_definitions(generics);
+        let parameters = Self::collect_generic_params(&lifetimes, &types);
+        let constraints = Self::collect_constraints(generics);
+
+        ParsedGenerics {
+            parameters,
+            constraints,
+        }
+    }
+
+    fn collect_generic_definitions(generics: &Generics) -> (Vec<Lifetime>, Vec<Ident>) {
+        let lifetimes = generics
+            .lifetimes()
+            .map(|definition| definition.lifetime.clone())
+            .collect();
+
+        let types = generics
+            .type_params()
+            .map(|type_param| type_param.ident.clone())
+            .collect();
+
+        (lifetimes, types)
+    }
+
+    fn collect_generic_params(lifetimes: &Vec<Lifetime>, types: &Vec<Ident>) -> Vec<TokenStream> {
+        let lifetimes = lifetimes.iter().map(|lifetime| quote! { #lifetime });
+        let types = types.iter().map(|type_param| quote! { #type_param });
+
+        lifetimes.chain(types).collect()
+    }
+
+    fn collect_constraints(generics: &Generics) -> Vec<TokenStream> {
+        let extra_type_constraint = Self::create_extra_type_constraint();
+        let extra_lifetime_constraints = iter::once(quote! { 'env: 'borrow });
+
+        let lifetime_constraints = generics
+            .lifetimes()
+            .filter(|definition| definition.colon_token.is_some())
+            .map(|definition| quote! { #definition });
+
+        let type_constraints = generics.type_params().cloned().map(|mut type_param| {
+            if type_param.colon_token.is_none() {
+                type_param.colon_token = Some(Token![:](Span::call_site()));
+            }
+
+            type_param.bounds.push(extra_type_constraint.clone());
+
+            quote! { #type_param }
+        });
+
+        lifetime_constraints
+            .chain(extra_lifetime_constraints)
+            .chain(type_constraints)
+            .collect()
+    }
+
+    fn create_extra_type_constraint() -> TypeParamBound {
+        TypeParamBound::Trait(TraitBound {
+            paren_token: None,
+            modifier: TraitBoundModifier::None,
+            lifetimes: None,
+            path: parse_str("jnix::IntoJava<'borrow, 'env>")
+                .expect("Invalid syntax in hardcoded string"),
+        })
+    }
+
+    pub fn impl_generics(&self) -> TokenStream {
+        let trait_parameters = [quote! { 'borrow }, quote! { 'env }];
+        let impl_parameters = trait_parameters.iter().chain(self.parameters.iter());
+
+        quote! { < #( #impl_parameters ),* > }
+    }
+
+    pub fn trait_generics(&self) -> TokenStream {
+        quote! { <'borrow, 'env> }
+    }
+
+    pub fn type_generics(&self) -> Option<TokenStream> {
+        let parameters = &self.parameters;
+
+        if parameters.is_empty() {
+            None
+        } else {
+            Some(quote! { < #( #parameters ),* > })
+        }
+    }
+
+    pub fn where_clause(&self) -> TokenStream {
+        let constraints = self.constraints.iter();
+
+        quote! { where #( #constraints ),* }
+    }
+}

--- a/jnix-macros/src/lib.rs
+++ b/jnix-macros/src/lib.rs
@@ -14,8 +14,11 @@ mod parsed_type;
 mod variants;
 
 use crate::{
-    attributes::JnixAttributes, fields::ParsedFields, generics::ParsedGenerics,
-    parsed_type::ParsedType, variants::ParsedVariants,
+    attributes::JnixAttributes,
+    fields::ParsedFields,
+    generics::{ParsedGenerics, TypeParameters},
+    parsed_type::ParsedType,
+    variants::ParsedVariants,
 };
 use proc_macro::TokenStream;
 use syn::{parse_macro_input, DeriveInput};

--- a/jnix-macros/src/lib.rs
+++ b/jnix-macros/src/lib.rs
@@ -43,6 +43,10 @@ use syn::{parse_macro_input, DeriveInput};
 /// conversion process, and therefore not used as a parameter for the constructor. The
 /// `#[jnix(skip_all)]` attribute can be used on the struct to skip all fields.
 ///
+/// The target class of a specific field can be set manually with the
+/// `#[jnix(target_class = "...")]` attribute. However, be aware that the target class must have
+/// the expected constructor with the parameter list based on the field order of the Rust type.
+///
 /// # Enums
 ///
 /// The generated `IntoJava` implementation for a enum that only has unit variants (i.e., no tuple

--- a/jnix-macros/src/lib.rs
+++ b/jnix-macros/src/lib.rs
@@ -9,12 +9,13 @@ extern crate proc_macro;
 
 mod attributes;
 mod fields;
+mod generics;
 mod parsed_type;
 mod variants;
 
 use crate::{
-    attributes::JnixAttributes, fields::ParsedFields, parsed_type::ParsedType,
-    variants::ParsedVariants,
+    attributes::JnixAttributes, fields::ParsedFields, generics::ParsedGenerics,
+    parsed_type::ParsedType, variants::ParsedVariants,
 };
 use proc_macro::TokenStream;
 use syn::{parse_macro_input, DeriveInput};

--- a/jnix-macros/src/parsed_type.rs
+++ b/jnix-macros/src/parsed_type.rs
@@ -1,4 +1,4 @@
-use crate::{JnixAttributes, ParsedFields, ParsedVariants};
+use crate::{JnixAttributes, ParsedFields, ParsedGenerics, ParsedVariants};
 use proc_macro2::{Span, TokenStream};
 use quote::quote;
 use syn::{Data, DeriveInput, Ident, LitStr};
@@ -6,6 +6,7 @@ use syn::{Data, DeriveInput, Ident, LitStr};
 pub struct ParsedType {
     attributes: JnixAttributes,
     type_name: Ident,
+    generics: ParsedGenerics,
     data: TypeData,
 }
 
@@ -17,6 +18,7 @@ impl ParsedType {
         ParsedType {
             attributes,
             type_name: input.ident,
+            generics: ParsedGenerics::new(&input.generics),
             data,
         }
     }
@@ -24,6 +26,11 @@ impl ParsedType {
     pub fn generate_into_java(self) -> TokenStream {
         let type_name = self.type_name;
         let type_name_literal = LitStr::new(&type_name.to_string(), Span::call_site());
+
+        let impl_generics = self.generics.impl_generics();
+        let trait_generics = self.generics.trait_generics();
+        let type_generics = self.generics.type_generics();
+        let where_clause = self.generics.where_clause();
 
         let class_name = self
             .attributes
@@ -41,7 +48,9 @@ impl ParsedType {
         );
 
         quote! {
-            impl<'borrow, 'env: 'borrow> jnix::IntoJava<'borrow, 'env> for #type_name {
+            impl #impl_generics jnix::IntoJava #trait_generics for #type_name #type_generics
+            #where_clause
+            {
                 const JNI_SIGNATURE: &'static str = concat!("L", #jni_class_name_literal, ";");
 
                 type JavaType = jnix::jni::objects::AutoLocal<'env, 'borrow>;

--- a/jnix-macros/src/parsed_type.rs
+++ b/jnix-macros/src/parsed_type.rs
@@ -1,4 +1,4 @@
-use crate::{JnixAttributes, ParsedFields, ParsedGenerics, ParsedVariants};
+use crate::{JnixAttributes, ParsedFields, ParsedGenerics, ParsedVariants, TypeParameters};
 use proc_macro2::{Span, TokenStream};
 use quote::quote;
 use syn::{Data, DeriveInput, Ident, LitStr};
@@ -45,6 +45,7 @@ impl ParsedType {
             &jni_class_name_literal,
             &type_name_literal,
             &class_name,
+            &self.generics.type_parameters(),
         );
 
         quote! {
@@ -83,17 +84,20 @@ impl TypeData {
         jni_class_name_literal: &LitStr,
         type_name_literal: &LitStr,
         class_name: &str,
+        type_parameters: &TypeParameters,
     ) -> TokenStream {
         match self {
             TypeData::Enum(variants) => variants.generate_enum_into_java(
                 jni_class_name_literal,
                 type_name_literal,
                 class_name,
+                type_parameters,
             ),
             TypeData::Struct(fields) => fields.generate_struct_into_java(
                 jni_class_name_literal,
                 type_name_literal,
                 class_name,
+                type_parameters,
             ),
         }
     }

--- a/jnix-macros/src/variants.rs
+++ b/jnix-macros/src/variants.rs
@@ -1,4 +1,4 @@
-use crate::{JnixAttributes, ParsedFields};
+use crate::{JnixAttributes, ParsedFields, TypeParameters};
 use proc_macro2::{Span, TokenStream};
 use quote::quote;
 use syn::{punctuated::Punctuated, Ident, LitStr, Token, Variant};
@@ -34,6 +34,7 @@ impl ParsedVariants {
         jni_class_name_literal: &LitStr,
         type_name_literal: &LitStr,
         class_name: &str,
+        type_parameters: &TypeParameters,
     ) -> TokenStream {
         let conversions = if self.enum_class {
             self.generate_enum_class_conversions(
@@ -46,6 +47,7 @@ impl ParsedVariants {
                 jni_class_name_literal,
                 type_name_literal,
                 class_name,
+                type_parameters,
             )
         };
 
@@ -111,6 +113,7 @@ impl ParsedVariants {
         jni_class_name_literal: &LitStr,
         type_name_literal: &LitStr,
         class_name: &str,
+        type_parameters: &TypeParameters,
     ) -> Vec<TokenStream> {
         let jni_class_name = jni_class_name_literal.value();
         let type_name = type_name_literal.value();
@@ -132,6 +135,7 @@ impl ParsedVariants {
                     &variant_jni_class_name_literal,
                     &variant_type_name_literal,
                     &variant_class_name,
+                    type_parameters,
                 )
             })
             .collect()


### PR DESCRIPTION
This PR adds support for types with generic type parameters for the procedural macro to derive `IntoJava`.

The type information is initially parsed into a `ParsedGenerics` helper type. The helper type by default includes the `'env: 'borrow` constraint necessary for implementing the `IntoJava` trait. It can then be used to generate the tokens for the generic parameters used in `impl`, the parameters passed to the `IntoJava` trait, the parameters used by the type, and the `where` clause with all the constraints.

There is also a `TypeParameter` helper type, which is just used to check if a type parameter (e.g., `T`) is used in a type definition (e.g., `HashMap<String, Vec<T>>`). This is used by the `ParsedFields` type so that when a generic type parameter is used in the field type, the parameter type used in the constructor becomes `java.lang.Object`. This is implemented to behave like Java's type erasure, where at runtime the generic type information is lost.

If a different Java parameter type is desired for the constructor, a `#[jnix(target_class = "...")]` attribute can be used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/jnix/9)
<!-- Reviewable:end -->
