### PR TITLE
Add derive feature to `jnix`

### DIFF
--- a/jnix/Cargo.toml
+++ b/jnix/Cargo.toml
@@ -7,7 +7,11 @@ categories = ["external-ffi-bindings"]
 repository = "https://github.com/mullvad/jnix"
 edition = "2018"
 
+[features]
+derive = ["jnix-macros"]
+
 [dependencies]
 jni = "0.14"
+jnix-macros = { optional = true, path = "../jnix-macros" }
 once_cell = "1"
 parking_lot = "0.9"

--- a/jnix/src/lib.rs
+++ b/jnix/src/lib.rs
@@ -12,3 +12,5 @@ mod into_java;
 mod jnix_env;
 
 pub use self::{as_jvalue::AsJValue, into_java::IntoJava, jnix_env::JnixEnv};
+#[cfg(feature = "derive")]
+pub use jnix_macros::IntoJava;


### PR DESCRIPTION
This PR is just a small change to make it easier to use the `jnix` crate. By enabling the `derive` feature, it will import the `jnix-macros` crate and export the necessary macros from the `jnix` main crate.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/jnix/10)
<!-- Reviewable:end -->
