### PR TITLE
Allow specifying only the package name

### DIFF
--- a/jnix-macros/src/lib.rs
+++ b/jnix-macros/src/lib.rs
@@ -25,8 +25,10 @@ use syn::{parse_macro_input, DeriveInput};
 
 /// Derives `IntoJava` for a type.
 ///
-/// The name of the target Java class must be specified using an attribute, like so:
-/// `#[jnix(class_name = "my.package.MyClass"]`.
+/// The name of the target Java class must be known for code generation. Either it can specified
+/// explicitly using an attribute, like so: `#[jnix(class_name = "my.package.MyClass"]`, or it can
+/// be derived from the Rust type name as long as the containing Java package is specified using an
+/// attribute, like so: `#[jnix(package = "my.package")]`.
 ///
 /// # Structs
 ///


### PR DESCRIPTION
Previously, every type that had `derive(IntoJava)` required a custom attribute `#[jnix(class_name = "my.package.MyClass")]`. This PR allows the type to have a shorter `#[jnix(package = "my.package")]` attribute instead, where the final class name is assumed to be the same as the Rust type name.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/jnix/11)
<!-- Reviewable:end -->
