### PR TITLE
Add missing description and license fields

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 name = "jnix"
+description = "High-level extensions to help with the usage of JNI in Rust code"
 version = "0.1.0"
 authors = ["Mullvad VPN <admin@mullvad.net>"]
 readme = "README.md"
+license = "Apache-2.0 OR MIT"
 keywords = ["ffi", "java", "jni"]
 categories = ["external-ffi-bindings"]
 repository = "https://github.com/mullvad/jnix"

--- a/jnix-macros/Cargo.toml
+++ b/jnix-macros/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 name = "jnix-macros"
+description = "Companion crate to jnix that provides proc-macros for interfacing JNI with Rust"
 version = "0.1.0"
 authors = ["Mullvad VPN <admin@mullvad.net>"]
 readme = "README.md"
+license = "Apache-2.0 OR MIT"
 keywords = ["ffi", "java", "jni"]
 categories = ["external-ffi-bindings"]
 repository = "https://github.com/mullvad/jnix"


### PR DESCRIPTION
This PR adds some missing meta-data necessary for publishing the crates in `crates.io`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/jnix/13)
<!-- Reviewable:end -->
