### PR TITLE
Allow skipping fields in tuple variants

### DIFF
--- a/jnix-macros/src/fields.rs
+++ b/jnix-macros/src/fields.rs
@@ -288,9 +288,15 @@ impl ParsedFields {
     }
 
     fn original_bindings(&self) -> impl Iterator<Item = Ident> + '_ {
-        self.fields
-            .iter()
-            .map(|field| Ident::new(&field.name, field.span))
+        let is_named = self.field_type == FieldType::Named;
+
+        self.fields.iter().map(move |field| {
+            if is_named && field.skip {
+                Ident::new(&format!("_{}", field.name), field.span)
+            } else {
+                Ident::new(&field.name, field.span)
+            }
+        })
     }
 
     fn source_bindings(&self) -> impl Iterator<Item = &Ident> + '_ {


### PR DESCRIPTION
Previously, fields could be skipped using the `#[jnix(skip)]` attribute. However, this didn't work for fields inside enum variants because the generated code wouldn't pattern match with the ignored fields in the `match` statement.

This PR changes the `ParsedFields` type to keep track of all fields, including the skipped fields. An extra flag is added to the skipped fields. This allows generating the correct pattern for matching with variants with skipped fields.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/jnix/15)
<!-- Reviewable:end -->
