### PR TITLE
Fix `Class<InetAddress>` local reference leak

### DIFF
--- a/src/into_java/implementations/std/net.rs
+++ b/src/into_java/implementations/std/net.rs
@@ -10,12 +10,9 @@ fn ipvx_addr_into_java<'borrow, 'env: 'borrow>(
     original_octets: &[u8],
     env: &'borrow JnixEnv<'env>,
 ) -> AutoLocal<'env, 'borrow> {
+    let class = env.get_class("java/net/InetAddress");
     let constructor = env
-        .get_static_method_id(
-            "java/net/InetAddress",
-            "getByAddress",
-            "([B)Ljava/net/InetAddress;",
-        )
+        .get_static_method_id(&class, "getByAddress", "([B)Ljava/net/InetAddress;")
         .expect("Failed to get InetAddress.getByAddress method ID");
 
     let octets_array = env


### PR DESCRIPTION
The `jni` crate is known to leak `Class` objects when they're referenced from strings (i.e., using a `"my/package/MyClass"` string for it to automatically load the `Class` object). The workaround is to use actual `JClass` references so that they can be used multiple times without reallocating them on the local reference stack.

Apparently one use case was still left to be fixed. This PR updates the `IntoJava` implementation for `IpAddr` (and its variants) so that it uses a `JClass` reference from the global class cache.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/jnix/16)
<!-- Reviewable:end -->
