### PR TITLE
Remove unused Mullvad email

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "jnix"
 description = "High-level extensions to help with the usage of JNI in Rust code"
 version = "0.1.1"
-authors = ["Mullvad VPN <admin@mullvad.net>"]
+authors = ["Mullvad VPN"]
 readme = "README.md"
 license = "Apache-2.0 OR MIT"
 keywords = ["ffi", "java", "jni"]

--- a/jnix-macros/Cargo.toml
+++ b/jnix-macros/Cargo.toml
@@ -2,7 +2,7 @@
 name = "jnix-macros"
 description = "Companion crate to jnix that provides proc-macros for interfacing JNI with Rust"
 version = "0.1.1"
-authors = ["Mullvad VPN <admin@mullvad.net>"]
+authors = ["Mullvad VPN"]
 readme = "README.md"
 license = "Apache-2.0 OR MIT"
 keywords = ["ffi", "java", "jni"]


### PR DESCRIPTION
The email address used in the author field is slowly being phased away, so it should be removed from all places it appears in.

This PR updates both package manifests to remove the email from the authors' field.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/jnix/18)
<!-- Reviewable:end -->
