### PR TITLE
Prepare to release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Line wrap the file at 100 characters. That is over here: -----------------------
 - **Security**: in case of vulnerabilities.
 
 ## [Unreleased]
+
+## [0.1.2] - 2020-01-22
 ### Fixed
 - Fix another instance of a local reference leak when calling `.into_java(env)` on an `IpAddr`,
   `Ipv4Addr` or `Ipv6Addr`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jnix"
 description = "High-level extensions to help with the usage of JNI in Rust code"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Mullvad VPN"]
 readme = "README.md"
 license = "Apache-2.0 OR MIT"
@@ -15,9 +15,9 @@ derive = ["jnix-macros"]
 
 [dependencies]
 jni = "0.14"
-jnix-macros = { version = "0.1.1", optional = true, path = "jnix-macros" }
+jnix-macros = { version = "0.1.2", optional = true, path = "jnix-macros" }
 once_cell = "1"
 parking_lot = "0.9"
 
 [dev-dependencies]
-jnix-macros = { version = "0.1.1", path = "jnix-macros" }
+jnix-macros = { version = "0.1.2", path = "jnix-macros" }

--- a/jnix-macros/Cargo.toml
+++ b/jnix-macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jnix-macros"
 description = "Companion crate to jnix that provides proc-macros for interfacing JNI with Rust"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Mullvad VPN"]
 readme = "README.md"
 license = "Apache-2.0 OR MIT"


### PR DESCRIPTION
This PR updates the manifest files and the changelog in preparation to release a new `0.1.2` patch release.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/jnix/20)
<!-- Reviewable:end -->
