### PR TITLE
Derive `FromJava` for structs

### DIFF
--- a/jnix-macros/Cargo.toml
+++ b/jnix-macros/Cargo.toml
@@ -17,6 +17,7 @@ path = "src/lib.rs"
 proc-macro = true
 
 [dependencies]
+heck = "0.3"
 proc-macro2 = "1"
 quote = "1"
 syn = { version = "1", features = ['full'] }

--- a/jnix-macros/src/fields.rs
+++ b/jnix-macros/src/fields.rs
@@ -1,4 +1,5 @@
 use crate::{JnixAttributes, TypeParameters};
+use heck::MixedCase;
 use proc_macro2::{Span, TokenStream};
 use quote::quote;
 use syn::{
@@ -168,6 +169,28 @@ impl ParsedFields {
         }
     }
 
+    pub fn generate_struct_from_java(
+        &self,
+        jni_class_name_literal: &LitStr,
+        class_name: &str,
+    ) -> TokenStream {
+        let names = self.original_bindings();
+        let constructor = self.generate_enum_variant_parameters();
+        let conversions = self.generate_from_java_conversions(class_name);
+        let class_binding = if self.fields.is_empty() {
+            quote! {}
+        } else {
+            quote! { let class = env.get_class(#jni_class_name_literal); }
+        };
+
+        quote! {
+            #class_binding
+            #( let #names = { #conversions }; )*
+
+            Self #constructor
+        }
+    }
+
     pub fn generate_struct_into_java(
         &self,
         jni_class_name_literal: &LitStr,
@@ -210,6 +233,40 @@ impl ParsedFields {
             #( let #source_bindings = #original_bindings; )*
             #conversion
         }
+    }
+
+    fn generate_from_java_conversions<'a, 'b: 'a>(
+        &'a self,
+        class_name: &'b str,
+    ) -> impl Iterator<Item = TokenStream> + 'a {
+        if let FieldType::Unnamed = self.field_type {
+            panic!("Can't derive FromJava for tuple structs");
+        }
+
+        self.fields.iter().map(move |field| {
+            let getter_name = format!("get_{}", field.name).to_mixed_case();
+            let getter_literal = LitStr::new(&getter_name, Span::call_site());
+            let field_type = field.get_type();
+
+            quote! {
+                let jni_signature =
+                    <#field_type as jnix::FromJava<jnix::jni::objects::JValue>>::JNI_SIGNATURE;
+
+                let method_signature = format!("(){}", jni_signature);
+                let method_id = env.get_method_id(&class, #getter_literal, &method_signature)
+                    .expect(
+                        concat!("Failed to get method ID for ", #class_name, "::", #getter_literal),
+                    );
+                let return_type = jni_signature.parse().unwrap_or_else(|_| {
+                    panic!("Invalid JNI signature: {}", jni_signature);
+                });
+
+                let java_value = env.call_method_unchecked(source, method_id, return_type, &[])
+                    .expect(concat!("Failed to call ", #class_name, "::", #getter_literal));
+
+                <#field_type as jnix::FromJava<_>>::from_java(env, java_value)
+            }
+        })
     }
 
     fn generate_into_java_conversion(

--- a/jnix-macros/src/fields.rs
+++ b/jnix-macros/src/fields.rs
@@ -239,10 +239,6 @@ impl ParsedFields {
         &'a self,
         class_name: &'b str,
     ) -> impl Iterator<Item = TokenStream> + 'a {
-        if let FieldType::Unnamed = self.field_type {
-            panic!("Can't derive FromJava for tuple structs");
-        }
-
         self.fields.iter().map(move |field| {
             let getter_name = format!("get_{}", field.name).to_mixed_case();
             let getter_literal = LitStr::new(&getter_name, Span::call_site());

--- a/jnix-macros/src/generics.rs
+++ b/jnix-macros/src/generics.rs
@@ -78,15 +78,6 @@ impl ParsedGenerics {
         quote! { < #( #impl_parameters ),* > }
     }
 
-    pub fn trait_generics(
-        &self,
-        trait_parameters: impl IntoIterator<Item = TokenStream>,
-    ) -> TokenStream {
-        let trait_parameters = trait_parameters.into_iter();
-
-        quote! { < #( #trait_parameters ),* > }
-    }
-
     pub fn type_generics(&self) -> Option<TokenStream> {
         let parameters = &self.parameters;
 

--- a/jnix-macros/src/lib.rs
+++ b/jnix-macros/src/lib.rs
@@ -24,6 +24,23 @@ use crate::{
 use proc_macro::TokenStream;
 use syn::{parse_macro_input, DeriveInput};
 
+/// Derives `FromJava` for a type.
+///
+/// More specifically, `FromJava<'env, JObject<'sub_env>>` is derived for the type. This also makes
+/// available a `FromJava<'env, AutoLocal<'sub_env, 'borrow>>` implementation through a blanket
+/// implementation.
+///
+/// The name of the target Java class must be known for code generation. Either it can be specified
+/// explicitly using an attribute, like so: `#[jnix(class_name = "my.package.MyClass"]`, or it can
+/// be derived from the Rust type name as long as the containing Java package is specified using an
+/// attribute, like so: `#[jnix(package = "my.package")]`.
+#[proc_macro_derive(FromJava, attributes(jnix))]
+pub fn derive_from_java(input: TokenStream) -> TokenStream {
+    let parsed_type = ParsedType::new(parse_macro_input!(input as DeriveInput));
+
+    TokenStream::from(parsed_type.generate_from_java())
+}
+
 /// Derives `IntoJava` for a type.
 ///
 /// The name of the target Java class must be known for code generation. Either it can be specified

--- a/jnix-macros/src/lib.rs
+++ b/jnix-macros/src/lib.rs
@@ -34,6 +34,49 @@ use syn::{parse_macro_input, DeriveInput};
 /// explicitly using an attribute, like so: `#[jnix(class_name = "my.package.MyClass"]`, or it can
 /// be derived from the Rust type name as long as the containing Java package is specified using an
 /// attribute, like so: `#[jnix(package = "my.package")]`.
+///
+/// # Structs
+///
+/// The generated `FromJava` implementation for a struct will construct the Rust type using values
+/// for the fields obtained using getter methods. Each field name is prefixed with `get_` before
+/// converted to mixed case (also known sometimes as camel case). Therefore, the source object must
+/// have the necessary getter methods for the Rust type to be constructed correctly.
+///
+/// # Examples
+///
+/// ## Structs with named fields
+///
+/// ```rust
+/// #[derive(FromJava)]
+/// #[jnix(package = "my.package")]
+/// pub struct MyClass {
+///     first_field: String,
+///     second_field: String,
+/// }
+/// ```
+///
+/// ```java
+/// package my.package;
+///
+/// public class MyClass {
+///     private String firstField;
+///     private String secondField;
+///
+///     public MyClass(String first, String second) {
+///         firstField = first;
+///         secondField = second;
+///     }
+///
+///     // The following getter methods are used to obtain the values to build the Rust struct.
+///     public String getFirstField() {
+///         firstField
+///     }
+///
+///     public String setSecondField() {
+///         secondField
+///     }
+/// }
+/// ```
 #[proc_macro_derive(FromJava, attributes(jnix))]
 pub fn derive_from_java(input: TokenStream) -> TokenStream {
     let parsed_type = ParsedType::new(parse_macro_input!(input as DeriveInput));

--- a/jnix-macros/src/lib.rs
+++ b/jnix-macros/src/lib.rs
@@ -26,7 +26,7 @@ use syn::{parse_macro_input, DeriveInput};
 
 /// Derives `IntoJava` for a type.
 ///
-/// The name of the target Java class must be known for code generation. Either it can specified
+/// The name of the target Java class must be known for code generation. Either it can be specified
 /// explicitly using an attribute, like so: `#[jnix(class_name = "my.package.MyClass"]`, or it can
 /// be derived from the Rust type name as long as the containing Java package is specified using an
 /// attribute, like so: `#[jnix(package = "my.package")]`.

--- a/jnix-macros/src/lib.rs
+++ b/jnix-macros/src/lib.rs
@@ -42,6 +42,10 @@ use syn::{parse_macro_input, DeriveInput};
 /// converted to mixed case (also known sometimes as camel case). Therefore, the source object must
 /// have the necessary getter methods for the Rust type to be constructed correctly.
 ///
+/// For tuple structs, since the fields don't have names, the field index starting from zero isr
+/// used as the name.  Therefore, the source object must have getter methods named `get0`, `get1`,
+/// `get2`, ..., `getN` for the "N" number of fields present in the Rust type.
+///
 /// # Examples
 ///
 /// ## Structs with named fields
@@ -73,6 +77,38 @@ use syn::{parse_macro_input, DeriveInput};
 ///     }
 ///
 ///     public String setSecondField() {
+///         secondField
+///     }
+/// }
+/// ```
+///
+/// ## Tuple structs
+///
+/// ```rust
+/// #[derive(FromJava)]
+/// #[jnix(class_name = "my.package.CustomClass")]
+/// pub struct MyTupleStruct(String, String);
+/// ```
+///
+/// ```java
+/// package my.package;
+///
+/// public class CustomClass {
+///     private String firstField;
+///     private String secondField;
+///
+///     public MyClass(String first, String second) {
+///         firstField = first;
+///         secondField = second;
+///     }
+///
+///     // The following getter methods are used to obtain the values to build the Rust tuple
+///     // struct.
+///     public String get0() {
+///         firstField
+///     }
+///
+///     public String set1() {
 ///         secondField
 ///     }
 /// }

--- a/jnix-macros/src/parsed_type.rs
+++ b/jnix-macros/src/parsed_type.rs
@@ -23,6 +23,32 @@ impl ParsedType {
         }
     }
 
+    pub fn generate_from_java(self) -> TokenStream {
+        let class_name = self.class_name();
+
+        let type_name = self.type_name;
+
+        let jni_class_name = class_name.replace(".", "/");
+        let jni_class_name_literal = LitStr::new(&jni_class_name, Span::call_site());
+
+        quote! {
+            impl<'env, 'sub_env> jnix::FromJava<'env, jnix::jni::objects::JObject<'sub_env>>
+                for #type_name
+            where
+                'env: 'sub_env,
+            {
+                const JNI_SIGNATURE: &'static str = concat!("L", #jni_class_name_literal, ";");
+
+                fn from_java(
+                    env: &jnix::JnixEnv<'env>,
+                    source: jnix::jni::objects::JObject<'sub_env>,
+                ) -> Self {
+                    todo!();
+                }
+            }
+        }
+    }
+
     pub fn generate_into_java(self) -> TokenStream {
         let class_name = self.class_name();
 

--- a/jnix-macros/src/parsed_type.rs
+++ b/jnix-macros/src/parsed_type.rs
@@ -55,10 +55,16 @@ impl ParsedType {
         let type_name = self.type_name;
         let type_name_literal = LitStr::new(&type_name.to_string(), Span::call_site());
 
-        let impl_generics = self.generics.impl_generics();
-        let trait_generics = self.generics.trait_generics();
+        let trait_parameters = vec![quote! { 'borrow }, quote! { 'env }];
+        let trait_constraint = vec![quote! { 'env: 'borrow }];
+        let extra_type_bound = vec![quote! { jnix::IntoJava<'borrow, 'env> }];
+
+        let impl_generics = self.generics.impl_generics(trait_parameters.clone());
+        let trait_generics = self.generics.trait_generics(trait_parameters);
         let type_generics = self.generics.type_generics();
-        let where_clause = self.generics.where_clause();
+        let where_clause = self
+            .generics
+            .where_clause(trait_constraint, extra_type_bound);
 
         let jni_class_name = class_name.replace(".", "/");
         let jni_class_name_literal = LitStr::new(&jni_class_name, Span::call_site());

--- a/jnix-macros/src/parsed_type.rs
+++ b/jnix-macros/src/parsed_type.rs
@@ -43,9 +43,11 @@ impl ParsedType {
         let jni_class_name = class_name.replace(".", "/");
         let jni_class_name_literal = LitStr::new(&jni_class_name, Span::call_site());
 
-        let body = self
-            .data
-            .generate_from_java_body(&jni_class_name_literal, &class_name);
+        let body = self.data.generate_from_java_body(
+            &jni_class_name_literal,
+            &class_name,
+            &self.generics.type_parameters(),
+        );
 
         quote! {
             impl #impl_generics jnix::FromJava #trait_generics for #type_name #type_generics
@@ -142,12 +144,15 @@ impl TypeData {
         self,
         jni_class_name_literal: &LitStr,
         class_name: &str,
+        type_parameters: &TypeParameters,
     ) -> TokenStream {
         match self {
             TypeData::Enum(_) => todo!(),
-            TypeData::Struct(fields) => {
-                fields.generate_struct_from_java(jni_class_name_literal, class_name)
-            }
+            TypeData::Struct(fields) => fields.generate_struct_from_java(
+                jni_class_name_literal,
+                class_name,
+                type_parameters,
+            ),
         }
     }
 

--- a/jnix-macros/src/parsed_type.rs
+++ b/jnix-macros/src/parsed_type.rs
@@ -60,7 +60,7 @@ impl ParsedType {
         let extra_type_bound = vec![quote! { jnix::IntoJava<'borrow, 'env> }];
 
         let impl_generics = self.generics.impl_generics(trait_parameters.clone());
-        let trait_generics = self.generics.trait_generics(trait_parameters);
+        let trait_generics = quote! { < #( #trait_parameters ),* > };
         let type_generics = self.generics.type_generics();
         let where_clause = self
             .generics

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,4 +81,4 @@ mod jnix_env;
 
 pub use self::{as_jvalue::AsJValue, from_java::FromJava, into_java::IntoJava, jnix_env::JnixEnv};
 #[cfg(feature = "derive")]
-pub use jnix_macros::IntoJava;
+pub use jnix_macros::{FromJava, IntoJava};


### PR DESCRIPTION
This PR implements a procedural macro to derive `FromJava` for Rust structs. The Rust struct is constructed from a `JObject` Java object reference wrapper by calling getter methods for all the Rust fields. The getter methods are assumed to have the format of a mixed-case (a.k.a. camel case) name of the Rust struct field prefixed with `get`. For example, a field named `my_field_in_the_rust_struct` is assumed to have an equivalent Java getter called `getMyFieldInTheRustStruct`.

Some refactoring of the code to generate the generic types and parameters for the generated trait implementations had to be refactored so that it could be independent of the `IntoJava` trait.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/jnix/22)
<!-- Reviewable:end -->
