### PR TITLE
Derive `FromJava` for enums

### DIFF
--- a/jnix-macros/src/lib.rs
+++ b/jnix-macros/src/lib.rs
@@ -54,6 +54,13 @@ use syn::{parse_macro_input, DeriveInput};
 /// and once an entry is found matching the source reference, the respective variant is
 /// constructed.
 ///
+/// When an enum has at least one tuple or struct variant, the generated `FromJava` implementation
+/// will assume that that there is a class hierarchy to represent the type. The source Java class
+/// is assumed to be the super class, and a nested static class for each variant is assumed to be
+/// declared in that super class. The source object is checked to see which of the sub-classes it
+/// is an instance of. Once a sub-class is found, the respective variant is created similarly to
+/// how a struct is constructed, so the same rules regarding the presence of getter methods apply.
+///
 /// # Examples
 ///
 /// ## Structs with named fields
@@ -138,6 +145,55 @@ use syn::{parse_macro_input, DeriveInput};
 ///
 /// public enum SimpleEnum {
 ///     First, Second
+/// }
+/// ```
+///
+/// ## Enums with fields
+///
+/// ```rust
+/// #[derive(FromJava)]
+/// #[jnix(package "my.package")]
+/// pub enum ComplexEnum {
+///     First {
+///         name: String,
+///     },
+///     Second(String, String),
+/// }
+/// ```
+///
+/// ```java
+/// package my.package;
+///
+/// public class ComplexEnum {
+///     public static class First extends ComplexEnum {
+///         private String name;
+///
+///         public First(String name) {
+///             this.name = name;
+///         }
+///
+///         public String getName() {
+///             return name;
+///         }
+///     }
+///
+///     public static class Second extends ComplexEnum {
+///         private String a;
+///         private String b;
+///
+///         public Second(String a, String b) {
+///             this.a = a;
+///             this.b = b;
+///         }
+///
+///         public String get0() {
+///             return a;
+///         }
+///
+///         public String get1() {
+///             return b;
+///         }
+///     }
 /// }
 /// ```
 #[proc_macro_derive(FromJava, attributes(jnix))]

--- a/jnix-macros/src/lib.rs
+++ b/jnix-macros/src/lib.rs
@@ -46,6 +46,14 @@ use syn::{parse_macro_input, DeriveInput};
 /// used as the name.  Therefore, the source object must have getter methods named `get0`, `get1`,
 /// `get2`, ..., `getN` for the "N" number of fields present in the Rust type.
 ///
+/// # Enums
+///
+/// The generate `FromJava` implementation for an enum that only has unit variants (i.e, no tuple
+/// or struct variants) assumes that the source object is an instance of an `enum class`. The
+/// source reference is compared to the static fields representing the entries of the `enum class`,
+/// and once an entry is found matching the source reference, the respective variant is
+/// constructed.
+///
 /// # Examples
 ///
 /// ## Structs with named fields
@@ -111,6 +119,25 @@ use syn::{parse_macro_input, DeriveInput};
 ///     public String set1() {
 ///         return secondField;
 ///     }
+/// }
+/// ```
+///
+/// ## Simple enums
+///
+/// ```rust
+/// #[derive(FromJava)]
+/// #[jnix(package "my.package")]
+/// pub enum SimpleEnum {
+///     First,
+///     Second,
+/// }
+/// ```
+///
+/// ```java
+/// package my.package;
+///
+/// public enum SimpleEnum {
+///     First, Second
 /// }
 /// ```
 #[proc_macro_derive(FromJava, attributes(jnix))]

--- a/jnix-macros/src/lib.rs
+++ b/jnix-macros/src/lib.rs
@@ -73,11 +73,11 @@ use syn::{parse_macro_input, DeriveInput};
 ///
 ///     // The following getter methods are used to obtain the values to build the Rust struct.
 ///     public String getFirstField() {
-///         firstField
+///         return firstField;
 ///     }
 ///
 ///     public String setSecondField() {
-///         secondField
+///         return secondField;
 ///     }
 /// }
 /// ```
@@ -105,11 +105,11 @@ use syn::{parse_macro_input, DeriveInput};
 ///     // The following getter methods are used to obtain the values to build the Rust tuple
 ///     // struct.
 ///     public String get0() {
-///         firstField
+///         return firstField;
 ///     }
 ///
 ///     public String set1() {
-///         secondField
+///         return secondField;
 ///     }
 /// }
 /// ```

--- a/jnix-macros/src/parsed_type.rs
+++ b/jnix-macros/src/parsed_type.rs
@@ -147,7 +147,9 @@ impl TypeData {
         type_parameters: &TypeParameters,
     ) -> TokenStream {
         match self {
-            TypeData::Enum(_) => todo!(),
+            TypeData::Enum(variants) => {
+                variants.generate_enum_from_java(jni_class_name_literal, class_name)
+            }
             TypeData::Struct(fields) => fields.generate_struct_from_java(
                 jni_class_name_literal,
                 class_name,

--- a/jnix-macros/src/parsed_type.rs
+++ b/jnix-macros/src/parsed_type.rs
@@ -147,9 +147,11 @@ impl TypeData {
         type_parameters: &TypeParameters,
     ) -> TokenStream {
         match self {
-            TypeData::Enum(variants) => {
-                variants.generate_enum_from_java(jni_class_name_literal, class_name)
-            }
+            TypeData::Enum(variants) => variants.generate_enum_from_java(
+                jni_class_name_literal,
+                class_name,
+                type_parameters,
+            ),
             TypeData::Struct(fields) => fields.generate_struct_from_java(
                 jni_class_name_literal,
                 class_name,

--- a/jnix-macros/src/variants.rs
+++ b/jnix-macros/src/variants.rs
@@ -37,13 +37,13 @@ impl ParsedVariants {
         type_parameters: &TypeParameters,
     ) -> TokenStream {
         let conversions = if self.enum_class {
-            self.generate_enum_class_conversions(
+            self.generate_enum_class_into_java_conversions(
                 jni_class_name_literal,
                 type_name_literal,
                 class_name,
             )
         } else {
-            self.generate_sealed_class_conversions(
+            self.generate_sealed_class_into_java_conversions(
                 jni_class_name_literal,
                 type_name_literal,
                 class_name,
@@ -69,7 +69,7 @@ impl ParsedVariants {
         }
     }
 
-    fn generate_enum_class_conversions(
+    fn generate_enum_class_into_java_conversions(
         &self,
         jni_class_name_literal: &LitStr,
         type_name_literal: &LitStr,
@@ -108,7 +108,7 @@ impl ParsedVariants {
             .collect()
     }
 
-    fn generate_sealed_class_conversions(
+    fn generate_sealed_class_into_java_conversions(
         &self,
         jni_class_name_literal: &LitStr,
         type_name_literal: &LitStr,


### PR DESCRIPTION
This PR implements the procedural macro to derive `FromJava` for enums. Simple enums whose variants don't have fields are mapped one to one to Java enums. Enums that have at least one variant with one or more fields are mapped to a class hierarchy, where it's assumed that there is a parent class with the same name as the Rust enum, and sub-classes each one named after one variant of the Rust enum.

A fix for the Java example in the documentation is also included in the PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/jnix/23)
<!-- Reviewable:end -->
