### PR TITLE
Skip variants in `FromJava`

### DIFF
--- a/jnix-macros/src/lib.rs
+++ b/jnix-macros/src/lib.rs
@@ -245,6 +245,10 @@ pub fn derive_from_java(input: TokenStream) -> TokenStream {
 /// assumed to have one inner class for each variant, and the conversion actually instantiates an
 /// object for the respective variant type, using the same rules for the fields as the rules for
 /// struct fields.
+///
+/// For both cases, variants can be prevented from being constructed from their respective Java
+/// entries or sub-classes by using the `#[jnix(deny)]` attribute. If one of the entries is used in
+/// an attempt to convert to the equivalent Rust variant, the code panics.
 #[proc_macro_derive(IntoJava, attributes(jnix))]
 pub fn derive_into_java(input: TokenStream) -> TokenStream {
     let parsed_type = ParsedType::new(parse_macro_input!(input as DeriveInput));


### PR DESCRIPTION
This PR adds a `#[jnix(deny)]` attribute that can be applied to enum variants when deriving `FromJava`. When a variant has this attribute, it is prevented from being constructed. That means that if the source Java type is mapped to the denied target variant, the generated code will panic.

This is useful for when a Rust variant is complex to be mapped to a Java type that's not actually used anywhere in Java.

A large part of this PR is a refactor to create a `ParsedVariant` helper type to simplify the final implementation. So instead of storing vectors of individual elements of interest (the names of the variants and the fields), a single vector stores instances of `ParsedVariant`, which contains the elements of interest for each variant.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/jnix/25)
<!-- Reviewable:end -->
