### PR TITLE
Implement `FromJava` for `bool`

### DIFF
--- a/src/from_java/implementations/std.rs
+++ b/src/from_java/implementations/std.rs
@@ -1,5 +1,8 @@
 use crate::{FromJava, JnixEnv};
-use jni::objects::{AutoLocal, JObject, JString, JValue};
+use jni::{
+    objects::{AutoLocal, JObject, JString, JValue},
+    sys::{jboolean, JNI_FALSE},
+};
 
 impl<'env, 'sub_env, T> FromJava<'env, JValue<'sub_env>> for T
 where
@@ -29,6 +32,14 @@ where
 
     fn from_java(env: &JnixEnv<'env>, source: AutoLocal<'sub_env, 'borrow>) -> Self {
         T::from_java(env, source.as_obj())
+    }
+}
+
+impl<'env> FromJava<'env, jboolean> for bool {
+    const JNI_SIGNATURE: &'static str = "Z";
+
+    fn from_java(_: &JnixEnv<'env>, source: jboolean) -> Self {
+        source != JNI_FALSE
     }
 }
 


### PR DESCRIPTION
This PR implements `FromJava<'env, jboolean>` for the Rust `bool` primitive. It compares the value to `JNI_FALSE` so that `0` is always `false`, and any other value is considered `true`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/jnix/26)
<!-- Reviewable:end -->
