### PR TITLE
Implement `IntoJava` for `Option<bool>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Line wrap the file at 100 characters. That is over here: -----------------------
 - **Security**: in case of vulnerabilities.
 
 ## [Unreleased]
+### Added
+- Implement `IntoJava` for `Option<bool>` to convert to a boxed `Boolean` object.
 
 ## [0.2.0] - 2020-02-05
 ### Added

--- a/src/into_java/implementations/std/mod.rs
+++ b/src/into_java/implementations/std/mod.rs
@@ -116,6 +116,29 @@ where
     }
 }
 
+impl<'borrow, 'env> IntoJava<'borrow, 'env> for Option<bool>
+where
+    'env: 'borrow,
+{
+    const JNI_SIGNATURE: &'static str = "Ljava/lang/Boolean;";
+
+    type JavaType = AutoLocal<'env, 'borrow>;
+
+    fn into_java(self, env: &'borrow JnixEnv<'env>) -> Self::JavaType {
+        match self {
+            Some(value) => {
+                let class = env.get_class("java/lang/Boolean");
+                let boxed_boolean = env
+                    .new_object(&class, "(Z)V", &[JValue::Bool(value as jboolean)])
+                    .expect("Failed to create boxed Boolean object");
+
+                env.auto_local(boxed_boolean)
+            }
+            None => env.auto_local(JObject::null()),
+        }
+    }
+}
+
 impl<'borrow, 'env, T> IntoJava<'borrow, 'env> for Vec<T>
 where
     'env: 'borrow,


### PR DESCRIPTION
Previously there was no implementation of `Option<bool>` (or any other `Option<P>` where `P` is a primitive type) because the implementation needs to return a `null` reference when converting `None`. This is only possible with reference types, so optional primitives couldn't be converted.

This PR implements `IntoJava` for `Option<bool>` by generating a boxed `Boolean` object reference. It is either `null` for `None` or a valid `AutoLocal` reference to a `Boolean` wrapper when `Some(value)` is converted.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/jnix/28)
<!-- Reviewable:end -->
