### PR TITLE
Implement boxed `Integer` conversions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Line wrap the file at 100 characters. That is over here: -----------------------
 - **Security**: in case of vulnerabilities.
 
 ## [Unreleased]
+### Added
+- Implement `FromJava<JObject>` for `i32` to convert from a boxed `Integer` object.
 
 ## [0.2.1] - 2020-03-10
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Line wrap the file at 100 characters. That is over here: -----------------------
 ## [Unreleased]
 ### Added
 - Implement `FromJava<JObject>` for `i32` to convert from a boxed `Integer` object.
+- Implement `IntoJava` for `Option<i32>` to convert to a boxed `Integer` object.
 
 ## [0.2.1] - 2020-03-10
 ### Added

--- a/src/into_java/implementations/std/mod.rs
+++ b/src/into_java/implementations/std/mod.rs
@@ -139,6 +139,29 @@ where
     }
 }
 
+impl<'borrow, 'env> IntoJava<'borrow, 'env> for Option<i32>
+where
+    'env: 'borrow,
+{
+    const JNI_SIGNATURE: &'static str = "Ljava/lang/Integer;";
+
+    type JavaType = AutoLocal<'env, 'borrow>;
+
+    fn into_java(self, env: &'borrow JnixEnv<'env>) -> Self::JavaType {
+        match self {
+            Some(value) => {
+                let class = env.get_class("java/lang/Integer");
+                let boxed_boolean = env
+                    .new_object(&class, "(I)V", &[JValue::Int(value as jint)])
+                    .expect("Failed to create boxed Integer object");
+
+                env.auto_local(boxed_boolean)
+            }
+            None => env.auto_local(JObject::null()),
+        }
+    }
+}
+
 impl<'borrow, 'env, T> IntoJava<'borrow, 'env> for Vec<T>
 where
     'env: 'borrow,


### PR DESCRIPTION
This PR implements the conversion from a boxed `Integer` Java object into the Rust `i32` primitive, and from `Option<i32>` into a boxed `Integer` Java object.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/jnix/31)
<!-- Reviewable:end -->
