### PR TITLE
Prepare to release v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Line wrap the file at 100 characters. That is over here: -----------------------
 - **Security**: in case of vulnerabilities.
 
 ## [Unreleased]
+
+## [0.2.2] - 2020-03-23
 ### Added
 - Implement `FromJava<JObject>` for `i32` to convert from a boxed `Integer` object.
 - Implement `IntoJava` for `Option<i32>` to convert to a boxed `Integer` object.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jnix"
 description = "High-level extensions to help with the usage of JNI in Rust code"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Mullvad VPN"]
 readme = "README.md"
 license = "Apache-2.0 OR MIT"
@@ -15,9 +15,9 @@ derive = ["jnix-macros"]
 
 [dependencies]
 jni = "0.14"
-jnix-macros = { version = "0.2.1", optional = true, path = "jnix-macros" }
+jnix-macros = { version = "0.2.2", optional = true, path = "jnix-macros" }
 once_cell = "1"
 parking_lot = "0.9"
 
 [dev-dependencies]
-jnix-macros = { version = "0.2.1", path = "jnix-macros" }
+jnix-macros = { version = "0.2.2", path = "jnix-macros" }

--- a/jnix-macros/Cargo.toml
+++ b/jnix-macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jnix-macros"
 description = "Companion crate to jnix that provides proc-macros for interfacing JNI with Rust"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Mullvad VPN"]
 readme = "README.md"
 license = "Apache-2.0 OR MIT"


### PR DESCRIPTION
This PR updates the changelog and the manifests in order to prepare to release a new version of `jnix` and `jnix-macros`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/jnix/32)
<!-- Reviewable:end -->
