### PR TITLE
Implement `IntoJava` for `i64`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Line wrap the file at 100 characters. That is over here: -----------------------
 - **Security**: in case of vulnerabilities.
 
 ## [Unreleased]
+### Added
+- Implement `IntoJava` for `i64`.
 
 ## [0.2.2] - 2020-03-23
 ### Added

--- a/src/into_java/implementations/std/mod.rs
+++ b/src/into_java/implementations/std/mod.rs
@@ -3,7 +3,7 @@ mod net;
 use crate::{IntoJava, JnixEnv};
 use jni::{
     objects::{AutoLocal, JList, JObject, JValue},
-    sys::{jboolean, jdouble, jint, jshort, jsize, JNI_FALSE, JNI_TRUE},
+    sys::{jboolean, jdouble, jint, jlong, jshort, jsize, JNI_FALSE, JNI_TRUE},
 };
 
 impl<'borrow, 'env: 'borrow> IntoJava<'borrow, 'env> for bool {
@@ -37,6 +37,16 @@ impl<'borrow, 'env: 'borrow> IntoJava<'borrow, 'env> for i32 {
 
     fn into_java(self, _: &'borrow JnixEnv<'env>) -> Self::JavaType {
         self as jint
+    }
+}
+
+impl<'borrow, 'env: 'borrow> IntoJava<'borrow, 'env> for i64 {
+    const JNI_SIGNATURE: &'static str = "J";
+
+    type JavaType = jlong;
+
+    fn into_java(self, _: &'borrow JnixEnv<'env>) -> Self::JavaType {
+        self as jlong
     }
 }
 


### PR DESCRIPTION
This PR adds a missing implementation of `IntoJava` for `i64`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/jnix/33)
<!-- Reviewable:end -->
