### PR TITLE
Implement `FromJava<JValue>` for `bool`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Line wrap the file at 100 characters. That is over here: -----------------------
 ### Added
 - Implement `FromJava` for `Vec<T>`.
 - Implement `FromJava` for `IpAddr`, `Ipv4Addr` and `Ipv6Addr`.
+- Implement `FromJava<JValue>` for `bool` so that it can be used in structs that derive `FromJava`.
 
 ## [0.2.3] - 2020-05-07
 ### Added

--- a/src/from_java/implementations/std/mod.rs
+++ b/src/from_java/implementations/std/mod.rs
@@ -46,6 +46,20 @@ impl<'env> FromJava<'env, jboolean> for bool {
     }
 }
 
+impl<'env, 'sub_env> FromJava<'env, JValue<'sub_env>> for bool
+where
+    'env: 'sub_env,
+{
+    const JNI_SIGNATURE: &'static str = "Z";
+
+    fn from_java(env: &JnixEnv<'env>, source: JValue<'sub_env>) -> Self {
+        match source {
+            JValue::Bool(boolean) => bool::from_java(env, boolean),
+            _ => panic!("Can't convert Java type, expected a boolean primitive"),
+        }
+    }
+}
+
 impl<'env, 'sub_env> FromJava<'env, JObject<'sub_env>> for i32
 where
     'env: 'sub_env,


### PR DESCRIPTION
This PR implements `FromJava<JValue>` for `bool`, allowing conversion from a Java `boolean` primitive. This is necessary for deriving `FromJava` for Rust types that have a `bool` field.

In theory, the implementation could also handle `Boolean` Java object instances, but since that requires a different signature, it could make things confusing. It's simpler (and safer) to use `Option<bool>` as the field type when converting from a `Boolean` instance, because the instance reference could be `null`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/jnix/37)
<!-- Reviewable:end -->
