### PR TITLE
Change the implementation of `FromJava<JValue>` for `i32`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,13 @@ Line wrap the file at 100 characters. That is over here: -----------------------
 - **Security**: in case of vulnerabilities.
 
 ## [Unreleased]
+### Changed
+- Implementation of `FromJava<JValue>` for `i32` now expects an `int` Java primitive instead of a
+  boxed `Integer` object, this means that when deriving `FromJava` for custom types, `i32` fields
+  must now have a respective `int` field in the respective Java class.
+
+### Removed
+- Implementation of `FromJava<JObject>` for `i32`.
 
 ## [0.2.4] - 2020-11-17
 ### Added

--- a/src/from_java/implementations/std/mod.rs
+++ b/src/from_java/implementations/std/mod.rs
@@ -68,23 +68,17 @@ impl<'env> FromJava<'env, jint> for i32 {
     }
 }
 
-impl<'env, 'sub_env> FromJava<'env, JObject<'sub_env>> for i32
+impl<'env, 'sub_env> FromJava<'env, JValue<'sub_env>> for i32
 where
     'env: 'sub_env,
 {
-    const JNI_SIGNATURE: &'static str = "Ljava/lang/Integer;";
+    const JNI_SIGNATURE: &'static str = "I";
 
-    fn from_java(env: &JnixEnv<'env>, source: JObject<'sub_env>) -> Self {
-        let class = env.get_class("java/lang/Integer");
-        let method_id = env
-            .get_method_id(&class, "intValue", "()I")
-            .expect("Failed to get method ID for Integer.intValue()");
-        let return_type = JavaType::Primitive(Primitive::Int);
-
-        env.call_method_unchecked(source, method_id, return_type, &[])
-            .expect("Failed to call Integer.intValue()")
-            .i()
-            .expect("Call to Integer.intValue() did not return an int primitive")
+    fn from_java(env: &JnixEnv<'env>, source: JValue<'sub_env>) -> Self {
+        match source {
+            JValue::Int(integer) => i32::from_java(env, integer),
+            _ => panic!("Can't convert Java type, expected an integer primitive"),
+        }
     }
 }
 

--- a/src/from_java/implementations/std/mod.rs
+++ b/src/from_java/implementations/std/mod.rs
@@ -4,7 +4,7 @@ use crate::{FromJava, JnixEnv};
 use jni::{
     objects::{AutoLocal, JObject, JString, JValue},
     signature::{JavaType, Primitive},
-    sys::{jboolean, JNI_FALSE},
+    sys::{jboolean, jint, JNI_FALSE},
 };
 
 impl<'env, 'sub_env, T> FromJava<'env, JValue<'sub_env>> for T
@@ -57,6 +57,14 @@ where
             JValue::Bool(boolean) => bool::from_java(env, boolean),
             _ => panic!("Can't convert Java type, expected a boolean primitive"),
         }
+    }
+}
+
+impl<'env> FromJava<'env, jint> for i32 {
+    const JNI_SIGNATURE: &'static str = "I";
+
+    fn from_java(_: &JnixEnv<'env>, source: jint) -> Self {
+        source as i32
     }
 }
 


### PR DESCRIPTION
Previously, there was an implementation of `FromJava<JObject>` for `i32`, to allow the conversion of Java's boxed `Integer` objects to Rust's `i32` type. However, that led to a blanket `FromJava<JValue>` implementation to appear, and that had the type signature of the `Integer` class. That meant that deriving `FromJava` for a Rust type that has an `i32` field required the equivalent Java class to have a getter that returned an `Integer` object, and not an `int` primitive.

This PR changes that, by removing the `FromJava<JObject>` implementation for `i32` and adding a manual `FromJava<JValue>` implementation for `i32` that expects an `int` primitive. Unfortunately, this breaks backwards compatibility, so the next release will have to increase the minor version.

A future PR will implement `FromJava<JObject>` for `Option<i32>` by converting from the boxed `Integer` object and properly handling a `null` value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/jnix/39)
<!-- Reviewable:end -->
