### PR TITLE
Implement `FromJava` for `Option<i32>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,13 +21,18 @@ Line wrap the file at 100 characters. That is over here: -----------------------
 - **Security**: in case of vulnerabilities.
 
 ## [Unreleased]
+### Added
+- Implement `FromJava` for `Option<i32>`.
+
 ### Changed
 - Implementation of `FromJava<JValue>` for `i32` now expects an `int` Java primitive instead of a
   boxed `Integer` object, this means that when deriving `FromJava` for custom types, `i32` fields
-  must now have a respective `int` field in the respective Java class.
+  must now have a respective `int` field in the respective Java class. If `Integer` object fields
+  are desired, the Rust field type should be `Option<i32>`.
 
 ### Removed
-- Implementation of `FromJava<JObject>` for `i32`.
+- Implementation of `FromJava<JObject>` for `i32`. If conversion from `Integer` objects is needed,
+  it's possible to use `Option<i32>` as the target Rust type.
 
 ## [0.2.4] - 2020-11-17
 ### Added

--- a/src/from_java/implementations/std/mod.rs
+++ b/src/from_java/implementations/std/mod.rs
@@ -139,6 +139,30 @@ where
     }
 }
 
+impl<'env, 'sub_env> FromJava<'env, JObject<'sub_env>> for Option<i32> {
+    const JNI_SIGNATURE: &'static str = "Ljava/lang/Integer;";
+
+    fn from_java(env: &JnixEnv<'env>, source: JObject<'sub_env>) -> Self {
+        if source.is_null() {
+            None
+        } else {
+            let class = env.get_class("java/lang/Integer");
+            let method_id = env
+                .get_method_id(&class, "intValue", "()I")
+                .expect("Failed to get method ID for Integer.intValue()");
+            let return_type = JavaType::Primitive(Primitive::Int);
+
+            let int_value = env
+                .call_method_unchecked(source, method_id, return_type, &[])
+                .expect("Failed to call Integer.intValue()")
+                .i()
+                .expect("Call to Integer.intValue() did not return an int primitive");
+
+            Some(int_value)
+        }
+    }
+}
+
 impl<'env, 'sub_env, T> FromJava<'env, JObject<'sub_env>> for Vec<T>
 where
     'env: 'sub_env,


### PR DESCRIPTION
This PR implements `FromJava` for `Option<i32>`, allowing the conversion of a Java `Integer` object (which can be `null`) into a Rust integer (or `None`, if the object is `null`). This conversion replaces the previous implementation of a Java `Integer` into a Rust `i32`, which would panic if a `null` `Integer` was used. The previous conversion was removed in a previous PR (#39).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/jnix/40)
<!-- Reviewable:end -->
