### PR TITLE
Prepare to release version 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Line wrap the file at 100 characters. That is over here: -----------------------
 - **Security**: in case of vulnerabilities.
 
 ## [Unreleased]
+
+## [0.3.0] - 2020-11-27
 ### Added
 - Implement `FromJava` for `Option<i32>`.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jnix"
 description = "High-level extensions to help with the usage of JNI in Rust code"
-version = "0.2.4"
+version = "0.3.0"
 authors = ["Mullvad VPN"]
 readme = "README.md"
 license = "Apache-2.0 OR MIT"
@@ -15,9 +15,9 @@ derive = ["jnix-macros"]
 
 [dependencies]
 jni = "0.14"
-jnix-macros = { version = "0.2.4", optional = true, path = "jnix-macros" }
+jnix-macros = { version = "0.3.0", optional = true, path = "jnix-macros" }
 once_cell = "1"
 parking_lot = "0.9"
 
 [dev-dependencies]
-jnix-macros = { version = "0.2.4", path = "jnix-macros" }
+jnix-macros = { version = "0.3.0", path = "jnix-macros" }

--- a/jnix-macros/Cargo.toml
+++ b/jnix-macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jnix-macros"
 description = "Companion crate to jnix that provides proc-macros for interfacing JNI with Rust"
-version = "0.2.4"
+version = "0.3.0"
 authors = ["Mullvad VPN"]
 readme = "README.md"
 license = "Apache-2.0 OR MIT"


### PR DESCRIPTION
This PR prepares for the release of version `0.3.0`. The minor version was incremented because types that have `FromJava` derived and have `i32` type fields are now handled differently. Previously, they would expect a Java `Integer` object, while now they expect a Java `int` primitive.

The PR adds a version section to the changelog and updates the version in the manifest files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/jnix/41)
<!-- Reviewable:end -->
