### PR TITLE
Allow specifying Java generic type bounds with an attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ Line wrap the file at 100 characters. That is over here: -----------------------
 - **Security**: in case of vulnerabilities.
 
 ## [Unreleased]
+### Added
+- Allow using a `#[jnix(bounds = "T: my.package.MyClass")]` attribute to specify the underlying
+  erased type used for a generic type parameter.
 
 ## [0.3.0] - 2020-11-27
 ### Added

--- a/jnix-macros/src/generics.rs
+++ b/jnix-macros/src/generics.rs
@@ -1,7 +1,7 @@
 use crate::JnixAttributes;
 use proc_macro2::{Span, TokenStream};
 use quote::quote;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use syn::{Generics, Ident, Lifetime, Path, ReturnType, Token, Type, TypeParam, TypeParamBound};
 
 pub struct ParsedGenerics {
@@ -92,7 +92,7 @@ impl ParsedGenerics {
 
     pub fn type_parameters(&self) -> TypeParameters {
         TypeParameters {
-            params: self.type_bounds.keys().cloned().collect(),
+            bounds: self.type_bounds.clone(),
         }
     }
 
@@ -157,7 +157,7 @@ impl ParsedGenerics {
 }
 
 pub struct TypeParameters {
-    params: HashSet<String>,
+    bounds: HashMap<String, String>,
 }
 
 impl TypeParameters {
@@ -213,7 +213,7 @@ impl TypeParameters {
 
     fn contains_path(&self, path: &Path) -> bool {
         path.get_ident()
-            .map(|ident| self.params.contains(&ident.to_string()))
+            .map(|ident| self.bounds.contains_key(&ident.to_string()))
             .unwrap_or(false)
     }
 

--- a/jnix-macros/src/generics.rs
+++ b/jnix-macros/src/generics.rs
@@ -1,23 +1,28 @@
+use crate::JnixAttributes;
 use proc_macro2::{Span, TokenStream};
 use quote::quote;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use syn::{Generics, Ident, Lifetime, Path, ReturnType, Token, Type, TypeParam, TypeParamBound};
 
 pub struct ParsedGenerics {
-    type_parameters: Vec<Ident>,
+    type_bounds: HashMap<String, String>,
     parameters: Vec<TokenStream>,
     lifetime_constraints: Vec<TokenStream>,
     type_constraints: Vec<TypeParam>,
 }
 
 impl ParsedGenerics {
-    pub fn new(generics: &Generics) -> Self {
+    pub fn new(generics: &Generics, attributes: &JnixAttributes) -> Self {
         let (lifetimes, types) = Self::collect_generic_definitions(generics);
         let parameters = Self::collect_generic_params(&lifetimes, &types);
         let (lifetime_constraints, type_constraints) = Self::collect_constraints(generics);
+        let bounds_attribute = attributes
+            .get_value("bounds")
+            .map(|literal| literal.value());
+        let type_bounds = Self::collect_type_bounds(types, bounds_attribute);
 
         ParsedGenerics {
-            type_parameters: types,
+            type_bounds,
             parameters,
             lifetime_constraints,
             type_constraints,
@@ -57,13 +62,37 @@ impl ParsedGenerics {
         (lifetime_constraints, type_constraints)
     }
 
+    fn collect_type_bounds(types: Vec<Ident>, bounds: Option<String>) -> HashMap<String, String> {
+        let mut type_bounds = if let Some(bounds_string) = bounds {
+            bounds_string
+                .split(",")
+                .filter_map(Self::parse_bounds_for_one_type)
+                .collect()
+        } else {
+            HashMap::with_capacity(types.len())
+        };
+
+        for maybe_unbounded_type in types.into_iter().map(|identifier| identifier.to_string()) {
+            if !type_bounds.contains_key(&maybe_unbounded_type) {
+                type_bounds.insert(maybe_unbounded_type, "Ljava/lang/Object;".to_owned());
+            }
+        }
+
+        type_bounds
+    }
+
+    fn parse_bounds_for_one_type(bounds_string: &str) -> Option<(String, String)> {
+        let mut parts = bounds_string.splitn(2, ":");
+        let bounded_type = parts.next()?.trim().to_owned();
+        let bound_class = parts.next()?.trim();
+        let bound_signature = format!("L{};", bound_class.replace('.', "/"));
+
+        Some((bounded_type, bound_signature))
+    }
+
     pub fn type_parameters(&self) -> TypeParameters {
         TypeParameters {
-            params: self
-                .type_parameters
-                .iter()
-                .map(|param| param.to_string())
-                .collect(),
+            params: self.type_bounds.keys().cloned().collect(),
         }
     }
 

--- a/jnix-macros/src/generics.rs
+++ b/jnix-macros/src/generics.rs
@@ -162,10 +162,19 @@ pub struct TypeParameters {
 
 impl TypeParameters {
     pub fn erased_type_for(&self, type_to_erase: &Type) -> Option<String> {
-        if self.is_used_in_type(type_to_erase) {
-            Some("Ljava/lang/Object;".to_owned())
-        } else {
-            None
+        match type_to_erase {
+            Type::Path(path) => {
+                let type_name = path.path.get_ident()?.to_string();
+
+                self.bounds.get(&type_name).cloned()
+            }
+            complex_path => {
+                if self.is_used_in_type(complex_path) {
+                    Some("Ljava/lang/Object;".to_owned())
+                } else {
+                    None
+                }
+            }
         }
     }
 

--- a/jnix-macros/src/generics.rs
+++ b/jnix-macros/src/generics.rs
@@ -132,6 +132,14 @@ pub struct TypeParameters {
 }
 
 impl TypeParameters {
+    pub fn erased_type_for(&self, type_to_erase: &Type) -> Option<String> {
+        if self.is_used_in_type(type_to_erase) {
+            Some("Ljava/lang/Object;".to_owned())
+        } else {
+            None
+        }
+    }
+
     pub fn is_used_in_type(&self, type_to_check: &Type) -> bool {
         match type_to_check {
             Type::Never(_) => false,

--- a/jnix-macros/src/generics.rs
+++ b/jnix-macros/src/generics.rs
@@ -140,7 +140,7 @@ impl TypeParameters {
         }
     }
 
-    pub fn is_used_in_type(&self, type_to_check: &Type) -> bool {
+    fn is_used_in_type(&self, type_to_check: &Type) -> bool {
         match type_to_check {
             Type::Never(_) => false,
 

--- a/jnix-macros/src/parsed_type.rs
+++ b/jnix-macros/src/parsed_type.rs
@@ -13,12 +13,13 @@ pub struct ParsedType {
 impl ParsedType {
     pub fn new(input: DeriveInput) -> Self {
         let attributes = JnixAttributes::new(&input.attrs);
+        let generics = ParsedGenerics::new(&input.generics, &attributes);
         let data = TypeData::from(input.data, &attributes);
 
         ParsedType {
             attributes,
             type_name: input.ident,
-            generics: ParsedGenerics::new(&input.generics),
+            generics,
             data,
         }
     }


### PR DESCRIPTION
The JVM does not support generics directly. What Java does is erase the generic type information when generating the final JVM bytecode. This means that `MyClass<T>` will get all of the `T` types used inside the class replaced with `Object`, allowing any valid object instance to be used. `jnix` already had some code to erase the generic type information when generating conversions.

When the generic type parameter has bounds, like for example `T extends Throwable`, Java will still erase the type `T`, but it will use `Throwable` instead of `Object`, since that's the strictest super class that supports all classes that could be `T`. `jnix` previously only supported erasing to the `Object` type. This PR changes that so that simple generic type parameters can have Java bounds specified through an attribute.

Now, using `#[jnix(bounds = "T: my.package.MyClass")]` causes the generated conversion to use `my.package.MyClass` as the erased type for `T`.

For more complex type usages (for example, when using `Vec<T>`), there is no logic to determine the correct erased type, so it will provide backwards compatibility by falling back to erasing to `Object`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/jnix/42)
<!-- Reviewable:end -->
