### PR TITLE
Replace indexed `get{N}` getters with `component{N+1}` getters generated by Kotlin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ Line wrap the file at 100 characters. That is over here: -----------------------
 - Allow using a `#[jnix(bounds = "T: my.package.MyClass")]` attribute to specify the underlying
   erased type used for a generic type parameter.
 
+### Changed
+- Derivation of `FromJava` for unnamed fields (i.e., tuple structs and tuple variants) now assumes
+  that each field with index N has a `component{N+1}` getter method instead of the previously
+  assumed `get{N}` method. This makes it easier to interface with Kotlin data classes, because it
+  automatically generates these `component{N+1}` getter methods for a `data class`.
+
 ## [0.3.0] - 2020-11-27
 ### Added
 - Implement `FromJava` for `Option<i32>`.


### PR DESCRIPTION
Currently, deriving `FromJava` for tuple structs and tuple enum variants requires the source Java object to have `getN` methods, where `N` is the index of the field. This is necessary because we can't deduce the property name from the Rust type because the fields are unnamed.

Kotlin has the concept of a `data class`. This is a Java class that has some extra methods generated for it. One set of methods is a set of getters for all properties specified in the primary constructor (which is usually all the fields necessary for that class). These getter methods are named `component1`, `component2`, etc..

This PR changes the `jnix-derive` crate to use those `component{N+1}` methods instead of the `get{N}` methods that were previously used. This allows Kotlin code to not have manually implemented indexed getter methods, and reduces the amount of boiler plate code that needs to be written.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/jnix/43)
<!-- Reviewable:end -->
