### PR TITLE
Use singleton classes to represent unit enum variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@ Line wrap the file at 100 characters. That is over here: -----------------------
   that each field with index N has a `component{N+1}` getter method instead of the previously
   assumed `get{N}` method. This makes it easier to interface with Kotlin data classes, because it
   automatically generates these `component{N+1}` getter methods for a `data class`.
+- Derivation of `IntoJava` for the unit variants of non-generic enums (i.e., the variants that have
+  no fields) now assume that the Java representation is a singleton class that has its instance
+  stored in a `INSTANCE` field. This allows Kotlin `object` variants to be used as the sub-classes
+  to represent the variants in a `sealed class`. Note that this does not change the assumption that
+  an enum that only has unit variants is represented as an `enum class`.
 
 ## [0.3.0] - 2020-11-27
 ### Added

--- a/jnix-macros/src/generics.rs
+++ b/jnix-macros/src/generics.rs
@@ -161,6 +161,10 @@ pub struct TypeParameters {
 }
 
 impl TypeParameters {
+    pub fn is_empty(&self) -> bool {
+        self.bounds.is_empty()
+    }
+
     pub fn erased_type_for(&self, type_to_erase: &Type) -> Option<String> {
         match type_to_erase {
             Type::Path(path) => {

--- a/jnix-macros/src/variants.rs
+++ b/jnix-macros/src/variants.rs
@@ -288,7 +288,7 @@ impl ParsedVariants {
                 let variant_jni_class_name_literal =
                     LitStr::new(&variant_jni_class_name, Span::call_site());
 
-                if variant.fields.is_unit() {
+                if variant.fields.is_unit() && type_parameters.is_empty() {
                     self.generate_unit_variant_into_java_conversion(
                         &variant_jni_class_name,
                         variant_jni_class_name_literal,


### PR DESCRIPTION
Previously, the `IntoJava` derive macro would assume that Rust enum types that had at least one enum variant with fields (either as a struct variant or a tuple variant) would be represented by a base class and one sub-class for each enum variant.

This PR changes that so that the unit variants (i.e., enum variants that have no fields) will now be represented by a Java singleton class, for which the instance can be obtained through an `INSTANCE` static field.

This maps to how enum variants are handled in Kotlin, which look something like this:

```
sealed class MyEnum {
    data class VariantWithFields(val field: Int) : MyEnum()
    object VariantWithoutFields
}
```

Unfortunately, this does not apply to types with generic type parameters because Java has type-erasure instead of monomorphization.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/jnix/44)
<!-- Reviewable:end -->
