### PR TITLE
Prepare to release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Line wrap the file at 100 characters. That is over here: -----------------------
 - **Security**: in case of vulnerabilities.
 
 ## [Unreleased]
+
+## [0.4.0] - 2021-02-17
 ### Added
 - Allow using a `#[jnix(bounds = "T: my.package.MyClass")]` attribute to specify the underlying
   erased type used for a generic type parameter.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ derive = ["jnix-macros"]
 jni = "0.14"
 jnix-macros = { version = "0.3.0", optional = true, path = "jnix-macros" }
 once_cell = "1"
-parking_lot = "0.9"
+parking_lot = "0.11"
 
 [dev-dependencies]
 jnix-macros = { version = "0.3.0", path = "jnix-macros" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jnix"
 description = "High-level extensions to help with the usage of JNI in Rust code"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Mullvad VPN"]
 readme = "README.md"
 license = "Apache-2.0 OR MIT"
@@ -15,9 +15,9 @@ derive = ["jnix-macros"]
 
 [dependencies]
 jni = "0.14"
-jnix-macros = { version = "0.3.0", optional = true, path = "jnix-macros" }
+jnix-macros = { version = "0.4.0", optional = true, path = "jnix-macros" }
 once_cell = "1"
 parking_lot = "0.11"
 
 [dev-dependencies]
-jnix-macros = { version = "0.3.0", path = "jnix-macros" }
+jnix-macros = { version = "0.4.0", path = "jnix-macros" }

--- a/README.md
+++ b/README.md
@@ -7,13 +7,14 @@ Some helper traits are provided, such as:
 
 - [`AsJValue`]: for allowing a JNI type to be convected to a `JValue` wrapper type.
 - [`IntoJava`]: for allowing a Rust type to be converted to a Java type.
+- [`FromJava`]: for allowing a Rust type to be created from a Java type.
 
 A [`JnixEnv`] helper type is also provided, which is a [`JNIEnv`] wrapper that contains an
 internal class cache for preloaded classes.
 
-If compiled with the `derive` feature flag, the crate also exports a [derive procedural macro
-for `IntoJava`][derive-into-java], which allows writing conversion code a lot easier.
-An example would be:
+If compiled with the `derive` feature flag, the crate also exports procedural macros to
+[derive `IntoJava`] and to [derive `FromJava`], which makes writing conversion code a lot
+easier.  An example would be:
 
 ```rust
 use jnix::{
@@ -22,7 +23,7 @@ use jnix::{
 };
 
 // Rust type definition
-#[derive(Default, IntoJava)]
+#[derive(Default, FromJava, IntoJava)]
 #[jnix(package = "my.package")]
 pub struct MyData {
     number: i32,
@@ -36,15 +37,17 @@ pub struct MyData {
 pub extern "system" fn Java_my_package_JniClass_getData<'env>(
     env: JNIEnv<'env>,
     _this: JObject<'env>,
+    data: JObject<'env>,
 ) -> JObject<'env> {
     // Create the `JnixEnv` wrapper
     let env = JnixEnv::from(env);
 
-    // Prepare the result type
-    let data = MyData::default();
+    // Convert parameter to Rust type
+    let data = MyData::from_java(&env, data);
 
-    // Since a smart pointer is returned from `into_java`, the inner object must be "leaked" so
-    // that the garbage collector can own it afterwards
+    // Create a new `MyData` object by converting from the Rust type. Since a smart pointer is
+    // returned from `into_java`, the inner object must be "leaked" sothat the garbage collector
+    // can own it afterwards
     data.into_java(&env).forget()
 }
 ```
@@ -60,13 +63,25 @@ public class MyData {
         // is for the target Java class to have a constructor with the expected type signature
         // following the field order of the Rust type.
     }
+
+    // These getters are called by the generated `FromJava` code
+    public int getNumber() {
+        return 10;
+    }
+
+    public String getString() {
+        return "string value";
+    }
 }
 ```
 
 [JNI]: https://en.wikipedia.org./wiki/Java_Native_Interface
 [`jni-rs`]: https://crates.io/crates/jni
 [`JNIEnv`]: https://docs.rs/jni/0.14.0/jni/struct.JNIEnv.html
-[`AsJValue`]: https://docs.rs/jnix/0.1.0/jnix/as_jvalue/trait.AsJValue.html
-[`IntoJava`]: https://docs.rs/jnix/0.1.0/jnix/into_java/trait.IntoJava.html
-[`JnixEnv`]: https://docs.rs/jnix/0.1.0/jnix/jnix_env/struct.JnixEnv.html
-[derive-into-java]: https://docs.rs/jnix-macros/0.1.0/jnix_macros/derive.IntoJava.html
+[`AsJValue`]: https://docs.rs/jnix/0.4.0/jnix/as_jvalue/trait.AsJValue.html
+[`IntoJava`]: https://docs.rs/jnix/0.4.0/jnix/into_java/trait.IntoJava.html
+[`JnixEnv`]: https://docs.rs/jnix/0.4.0/jnix/jnix_env/struct.JnixEnv.html
+[derive `IntoJava`]: https://docs.rs/jnix-macros/0.4.0/jnix_macros/derive.IntoJava.html
+[derive `FromJava`]: https://docs.rs/jnix-macros/0.4.0/jnix_macros/derive.FromJava.html
+
+License: Apache-2.0 OR MIT

--- a/jnix-macros/Cargo.toml
+++ b/jnix-macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jnix-macros"
 description = "Companion crate to jnix that provides proc-macros for interfacing JNI with Rust"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Mullvad VPN"]
 readme = "README.md"
 license = "Apache-2.0 OR MIT"

--- a/src/as_jvalue.rs
+++ b/src/as_jvalue.rs
@@ -2,11 +2,11 @@ use jni::objects::{AutoLocal, JValue};
 
 /// Returns a value as its [`JValue`] representation.
 ///
-/// [`JValue`]: https://docs.rs/jni/0.14.0/jni/objects/enum.JValue.html
+/// [`JValue`]: jni::objects::JValue
 pub trait AsJValue<'env> {
     /// Returns the [`JValue`] representation of the type.
     ///
-    /// [`JValue`]: https://docs.rs/jni/0.14.0/jni/objects/enum.JValue.html
+    /// [`JValue`]: jni::objects::JValue
     fn as_jvalue<'borrow>(&'borrow self) -> JValue<'borrow>
     where
         'env: 'borrow;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,10 +63,10 @@
 //!
 //! [JNI]: https://en.wikipedia.org./wiki/Java_Native_Interface
 //! [`jni-rs`]: https://crates.io/crates/jni
-//! [`JNIEnv`]: https://docs.rs/jni/0.14.0/jni/struct.JNIEnv.html
-//! [`AsJValue`]: https://docs.rs/jnix/0.1.0/jnix/as_jvalue/trait.AsJValue.html
-//! [`IntoJava`]: https://docs.rs/jnix/0.1.0/jnix/into_java/trait.IntoJava.html
-//! [`JnixEnv`]: https://docs.rs/jnix/0.1.0/jnix/jnix_env/struct.JnixEnv.html
+//! [`JNIEnv`]: jni::JNIEnv
+//! [`AsJValue`]: as_jvalue::AsJValue
+//! [`IntoJava`]: into_java::IntoJava
+//! [`JnixEnv`]: jnix_env::JnixEnv
 //! [derive-into-java]: https://docs.rs/jnix-macros/0.1.0/jnix_macros/derive.IntoJava.html
 
 #![deny(missing_docs)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,7 @@
 //! [`AsJValue`]: as_jvalue::AsJValue
 //! [`IntoJava`]: into_java::IntoJava
 //! [`JnixEnv`]: jnix_env::JnixEnv
-//! [derive-into-java]: https://docs.rs/jnix-macros/0.1.0/jnix_macros/derive.IntoJava.html
+//! [derive-into-java]: ../jnix_macros/derive.IntoJava.html
 
 #![deny(missing_docs)]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,22 +5,23 @@
 //!
 //! - [`AsJValue`]: for allowing a JNI type to be convected to a `JValue` wrapper type.
 //! - [`IntoJava`]: for allowing a Rust type to be converted to a Java type.
+//! - [`FromJava`]: for allowing a Rust type to be created from a Java type.
 //!
 //! A [`JnixEnv`] helper type is also provided, which is a [`JNIEnv`] wrapper that contains an
 //! internal class cache for preloaded classes.
 //!
-//! If compiled with the `derive` feature flag, the crate also exports a [derive procedural macro
-//! for `IntoJava`][derive-into-java], which allows writing conversion code a lot easier.
-//! An example would be:
+//! If compiled with the `derive` feature flag, the crate also exports procedural macros to
+//! [derive `IntoJava`] and to [derive `FromJava`], which makes writing conversion code a lot
+//! easier.  An example would be:
 //!
 //! ```rust
 //! use jnix::{
 //!     jni::{objects::JObject, JNIEnv},
-//!     JnixEnv, IntoJava,
+//!     JnixEnv, FromJava, IntoJava,
 //! };
 //!
 //! // Rust type definition
-//! #[derive(Default, IntoJava)]
+//! #[derive(Default, FromJava, IntoJava)]
 //! #[jnix(package = "my.package")]
 //! pub struct MyData {
 //!     number: i32,
@@ -34,15 +35,17 @@
 //! pub extern "system" fn Java_my_package_JniClass_getData<'env>(
 //!     env: JNIEnv<'env>,
 //!     _this: JObject<'env>,
+//!     data: JObject<'env>,
 //! ) -> JObject<'env> {
 //!     // Create the `JnixEnv` wrapper
 //!     let env = JnixEnv::from(env);
 //!
-//!     // Prepare the result type
-//!     let data = MyData::default();
+//!     // Convert parameter to Rust type
+//!     let data = MyData::from_java(&env, data);
 //!
-//!     // Since a smart pointer is returned from `into_java`, the inner object must be "leaked" so
-//!     // that the garbage collector can own it afterwards
+//!     // Create a new `MyData` object by converting from the Rust type. Since a smart pointer is
+//!     // returned from `into_java`, the inner object must be "leaked" sothat the garbage collector
+//!     // can own it afterwards
 //!     data.into_java(&env).forget()
 //! }
 //! ```
@@ -58,6 +61,15 @@
 //!         // is for the target Java class to have a constructor with the expected type signature
 //!         // following the field order of the Rust type.
 //!     }
+//!
+//!     // These getters are called by the generated `FromJava` code
+//!     public int getNumber() {
+//!         return 10;
+//!     }
+//!
+//!     public String getString() {
+//!         return "string value";
+//!     }
 //! }
 //! ```
 //!
@@ -67,7 +79,8 @@
 //! [`AsJValue`]: as_jvalue::AsJValue
 //! [`IntoJava`]: into_java::IntoJava
 //! [`JnixEnv`]: jnix_env::JnixEnv
-//! [derive-into-java]: ../jnix_macros/derive.IntoJava.html
+//! [derive `IntoJava`]: ../jnix_macros/derive.IntoJava.html
+//! [derive `FromJava`]: ../jnix_macros/derive.FromJava.html
 
 #![deny(missing_docs)]
 


### PR DESCRIPTION
This PR prepares the Jnix crate for another release with breaking changes. Namely, how `enum`s that have at least one non-unit variant (i.e., a tuple variant or a struct variant) will now use singletons for the unit variants when deriving `IntoJava` (see #44) and the getters used when deriving `FromJava` are now based on Kotlin's `componentN` methods instead of custom `getN` methods (see #43).

As part of this release, the `parking_lot` dependency was updated to the latest version and the documentation was updated to fix links to old versions and to have the main example include usage of `FromJava`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/jnix/45)
<!-- Reviewable:end -->
