### PR TITLE
Bump jni to 0.19 due to missing 'is_same_object' method in JNIEnv

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 derive = ["jnix-macros"]
 
 [dependencies]
-jni = "0.14"
+jni = "0.19"
 jnix-macros = { version = "0.4.0", optional = true, path = "jnix-macros" }
 once_cell = "1"
 parking_lot = "0.11"

--- a/src/from_java/implementations/std/net.rs
+++ b/src/from_java/implementations/std/net.rs
@@ -7,7 +7,7 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 fn read_inet_address_octets<'env, 'o>(env: &JnixEnv<'env>, source: JObject<'o>) -> JObject<'env>
 where
-    'env: 'o,
+    'o: 'env,
 {
     let class = env.get_class("java/net/InetAddress");
     let method_id = env

--- a/src/into_java/implementations/std/mod.rs
+++ b/src/into_java/implementations/std/mod.rs
@@ -210,6 +210,6 @@ impl<'borrow, 'env: 'borrow> IntoJava<'borrow, 'env> for String {
     fn into_java(self, env: &'borrow JnixEnv<'env>) -> Self::JavaType {
         let jstring = env.new_string(&self).expect("Failed to create Java String");
 
-        env.auto_local(jstring.into())
+        env.auto_local(jstring)
     }
 }


### PR DESCRIPTION
Previously, the derivation of `FromJava` failed for enums with only unit-like variants. The reason was that `JNIEnv::is_same_object` was nowhere to be found in `jni 0.14`. This PR fixes this by simply updating `jni` to `0.19`.