### PR TITLE
Prepare to release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@ Line wrap the file at 100 characters. That is over here: -----------------------
 
 ## [Unreleased]
 
+## [0.5.0] - 2022-09-14
+### Fixed
+- Fix broken derivation of `FromJava` for enums with only unit variants.
+
+### Changed
+- Upgrade `jni` to `0.19`.
+
 ## [0.4.0] - 2021-02-17
 ### Added
 - Allow using a `#[jnix(bounds = "T: my.package.MyClass")]` attribute to specify the underlying

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ derive = ["jnix-macros"]
 jni = "0.19"
 jnix-macros = { version = "0.4.0", optional = true, path = "jnix-macros" }
 once_cell = "1"
-parking_lot = "0.11"
+parking_lot = "0.12.1"
 
 [dev-dependencies]
 jnix-macros = { version = "0.4.0", path = "jnix-macros" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jnix"
 description = "High-level extensions to help with the usage of JNI in Rust code"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Mullvad VPN"]
 readme = "README.md"
 license = "Apache-2.0 OR MIT"
@@ -15,9 +15,9 @@ derive = ["jnix-macros"]
 
 [dependencies]
 jni = "0.19"
-jnix-macros = { version = "0.4.0", optional = true, path = "jnix-macros" }
+jnix-macros = { version = "0.4.1", optional = true, path = "jnix-macros" }
 once_cell = "1"
 parking_lot = "0.12.1"
 
 [dev-dependencies]
-jnix-macros = { version = "0.4.0", path = "jnix-macros" }
+jnix-macros = { version = "0.4.1", path = "jnix-macros" }

--- a/jnix-macros/Cargo.toml
+++ b/jnix-macros/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/lib.rs"
 proc-macro = true
 
 [dependencies]
-heck = "0.3"
+heck = "0.4"
 proc-macro2 = "1"
 quote = "1"
 syn = { version = "1", features = ['full'] }

--- a/jnix-macros/Cargo.toml
+++ b/jnix-macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jnix-macros"
 description = "Companion crate to jnix that provides proc-macros for interfacing JNI with Rust"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Mullvad VPN"]
 readme = "README.md"
 license = "Apache-2.0 OR MIT"

--- a/jnix-macros/src/fields.rs
+++ b/jnix-macros/src/fields.rs
@@ -1,5 +1,5 @@
 use crate::{JnixAttributes, TypeParameters};
-use heck::MixedCase;
+use heck::ToLowerCamelCase;
 use proc_macro2::{Span, TokenStream};
 use quote::quote;
 use syn::{
@@ -66,7 +66,7 @@ impl ParsedField {
     pub fn getter(&self) -> LitStr {
         let getter_name = match self.unnamed_field_index {
             Some(index) => format!("component{}", index + 1),
-            None => format!("get_{}", self.name).to_mixed_case(),
+            None => format!("get_{}", self.name).to_lower_camel_case(),
         };
 
         LitStr::new(&getter_name, self.span)


### PR DESCRIPTION
This version contains very few changes. Primarily, it fixes the derivation of `FromJava` for enums with only unit variants. It also upgrades `parking_lot` and `heck`.

I've bumped the minor version since `jni` is re-exported.