### PR TITLE
Prepare to release 0.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Line wrap the file at 100 characters. That is over here: -----------------------
 - **Security**: in case of vulnerabilities.
 
 ## [Unreleased]
+
+## [0.5.3] - 2025-04-01
 ### Added
 - Implement `FromJava` for `HashMap<K, V>`.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jnix"
 description = "High-level extensions to help with the usage of JNI in Rust code"
-version = "0.5.2"
+version = "0.5.3"
 authors = ["Mullvad VPN"]
 readme = "README.md"
 license = "Apache-2.0 OR MIT"


### PR DESCRIPTION
The release only includes a `FromJava` implementation for `HashMap`.